### PR TITLE
add build.sh -version version.json support

### DIFF
--- a/src/common/cl_main.c
+++ b/src/common/cl_main.c
@@ -66,7 +66,7 @@ void cl_log_system_info()
 #ifdef _VMR_VERSION_
 	CL_LOG(APP_MAIN,
 		"\r\ngit hash: %s.\r\ngit branch: %s.\r\nbuild date: %s",
-		VMR_GIT_HASH, VMR_GIT_BRANCH, VMR_GIT_BUILD_DATE);
+		VMR_GIT_HASH, VMR_GIT_BRANCH, VMR_GIT_HASH_DATE);
 #endif
 
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Now, we can take the version from version.json

=== VMR github info ===
VMR_GIT_BRANCH "firewall"
VMR_GIT_HASH_DATE "Thu, 20 Jan 2022 13:53:54 -0800"
VMR_GIT_HASH "ed4ba91b72eb9a5bfec254e9e3ccc722ca4a0de5"
=== VMR github info ===

**example of: ./build.sh -app -version version.json**
=== VMR github info ===
VMR_GIT_HASH_DATE "Fri, 9 Jul 2021 09:57:32 -0700"
VMR_GIT_HASH "9bbf5df10a52d432e393d8cd3978d213313afe2b"
VMR_GIT_BRANCH "master"
=== VMR github info ===

xsjrdevl171:build $ cat version.json
{
  "BUILD_VERSION" : "2.12.0",
  "BUILD_VERSION_DATE" : "Mon, 12 Jul 2021 20:22:36 +0000",
  "BUILD_BRANCH" : "master",
  "VERSION_HASH" : "9bbf5df10a52d432e393d8cd3978d213313afe2b",
  "VERSION_HASH_DATE" : "Fri, 9 Jul 2021 09:57:32 -0700"
}

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
