### PR TITLE
CR-1118124 ASTeR TC 4.02 - vck5000 - NOC error occurring when a firew…

### DIFF
--- a/src/rmgmt/rmgmt_xfer.c
+++ b/src/rmgmt/rmgmt_xfer.c
@@ -187,7 +187,7 @@ int rmgmt_init_handler(struct rmgmt_handler *rh)
 	return 0;
 }
 
-static int fpga_pl_pdi_download_workaround(UINTPTR data, UINTPTR size, bool has_pl)
+static int fpga_pdi_download_workaround(UINTPTR data, UINTPTR size, bool has_pl)
 {
 	int ret;
 	XFpga XFpgaInstance = { 0U };
@@ -261,7 +261,7 @@ static int rmgmt_fpga_download(struct rmgmt_handler *rh, u32 len)
 	/* Sync data from cache to memory */
 	Xil_DCacheFlush();
 
-	ret = fpga_pl_pdi_download_workaround((UINTPTR)((const char *)axlf + offset),
+	ret = fpga_pdi_download_workaround((UINTPTR)((const char *)axlf + offset),
 		(UINTPTR)size, true);
 
 	RMGMT_LOG("FPGA load pdi ret: %d", ret);
@@ -353,7 +353,7 @@ static int rmgmt_ospi_apu_download(struct rmgmt_handler *rh, u32 len)
 	 * when loading an APU or any other PDI type which does not change the ULP.
 	 * set ulp_changed to false.
 	 */
-	ret = fpga_pl_pdi_download_workaround((UINTPTR)((const char *)axlf + offset),
+	ret = fpga_pdi_download_workaround((UINTPTR)((const char *)axlf + offset),
 		(UINTPTR)size, false);
 
 	RMGMT_LOG("FPGA load pdi ret: %d", ret);


### PR DESCRIPTION
…all trip is attempted with a read

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
I believe the reason that PR Isolation is released, is that XRT/VMR autonomously loads an APU PDI after the card has booted. If this is using the same PDI loader as for a kernel PDI, then the final step is to enable the UCS Clocks, and release the isolation interface.

If this is the case, **then the UCS and PR Isolation operations (both disable before the PDI download and enable after the PDI download) should only be performed when loading a kernel PDI, and should not be performed when loading an APU or any other PDI type which does not change the ULP.**

To test this theory, if I enable isolation of the ULP
RPU : mwr -force 0x80020000 0x0
and then attempt to read from the ULP
sudo ~/rwmem 0xC2FF0000000
0x00000c2ff0000000 = 0xdeadfa11
The expected DEADFA11 is reported.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
