### PR TITLE
Add CS2200 Platform source code

### DIFF
--- a/src/common/cl_gpio.c
+++ b/src/common/cl_gpio.c
@@ -1,0 +1,89 @@
+/******************************************************************************
+ * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "xparameters.h"
+#include "xgpiops.h"
+#include "cl_gpio.h"
+#include "cl_log.h"
+
+
+#define LPD_GPIO_BASE XPAR_BLP_CIPS_PSPMC_0_PSV_GPIO_2_BASEADDR
+#define PMC_GPIO_BASE XPAR_BLP_CIPS_PSPMC_0_PSV_PMC_GPIO_0_BASEADDR
+
+
+#define LPD_GPIO_DEVICE_ID 	XPAR_BLP_CIPS_PSPMC_0_PSV_GPIO_2_DEVICE_ID
+#define PMC_GPIO_DEVICE_ID	XPAR_BLP_CIPS_PSPMC_0_PSV_PMC_GPIO_0_DEVICE_ID
+
+XGpioPs_Config gpioConfig[] = {
+		{LPD_GPIO_DEVICE_ID,LPD_GPIO_BASE},
+		{PMC_GPIO_DEVICE_ID,PMC_GPIO_BASE}
+};
+
+XGpioPs Gpio[2];	/* The driver instance for GPIO Device. */
+
+
+u8 GPIOInit(void)
+{
+
+	//XGpioPs *ConfigPtr = XGpioPs_LookupConfig(GPIO_DEVICE_ID);
+
+	/* Access PMC GPIO by setting to TRUE */
+	Gpio[PMC_GPIO_PORT].PmcGpio =  TRUE;
+	int Status = XGpioPs_CfgInitialize(&Gpio[PMC_GPIO_PORT], &gpioConfig[PMC_GPIO_PORT],
+			gpioConfig[PMC_GPIO_PORT].BaseAddr);
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+
+	CL_LOG(APP_MAIN,"GPIO0 max pins %u, banks %u\n\r", Gpio[0].MaxPinNum,Gpio[0].MaxBanks);
+
+	Gpio[LPD_GPIO_PORT].PmcGpio =  FALSE;
+	Status = XGpioPs_CfgInitialize(&Gpio[LPD_GPIO_PORT], &gpioConfig[LPD_GPIO_PORT],
+			gpioConfig[LPD_GPIO_PORT].BaseAddr);
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+	CL_LOG(APP_MAIN,"GPIO1 max pins %u, banks %u\n\r", Gpio[1].MaxPinNum,Gpio[1].MaxBanks);
+
+	/* Config pins */
+	CL_LOG(APP_MAIN,"Setting pin polarities and initial state.\n\r");
+
+	GPIOWriteOutput(LPD_GPIO_PORT,GPIO_PIN_FRU_EEPROM_WP,DEASSERTED);
+
+	GPIOWriteOutput(LPD_GPIO_PORT,GPIO_PIN_VPD_EEPROM_WP,ASSERTED);
+
+	/* SMBus EN. 0 for VPD EEPROM in master, 1 for ADK in Slave */
+	GPIOWriteOutput(LPD_GPIO_PORT,GPIO_PIN_VPD_EEPROM_SMBUS_SELECT,ASSERTED);
+
+	GPIOWriteOutput(LPD_GPIO_PORT,GPIO_PIN_SPI_FLASH_CS,DEASSERTED);
+
+
+	return XST_SUCCESS;
+}
+
+
+u8 GPIOReadInput(uint32_t port, uint32_t theBit, uint32_t *value)
+{
+	if (Gpio[port].MaxPinNum <= theBit)
+		return XST_FAILURE;
+
+	XGpioPs_SetDirectionPin(&Gpio[port], theBit, INPUT_PIN);
+	u32 Data = XGpioPs_ReadPin(&Gpio[port], theBit);
+	*value = Data;
+	return XST_SUCCESS;
+}
+u8 GPIOWriteOutput(uint32_t port, uint32_t theBit, uint32_t value)
+{
+	if (Gpio[port].MaxPinNum <= theBit)
+		return XST_FAILURE;
+
+	XGpioPs_SetDirectionPin(&Gpio[port], theBit, OUTPUT_PIN);
+	XGpioPs_WritePin(&Gpio[port], theBit, value);
+
+	return XST_SUCCESS;
+}
+

--- a/src/common/cl_main.c
+++ b/src/common/cl_main.c
@@ -13,7 +13,7 @@
 #include "cl_main.h"
 #include "cl_log.h"
 #include "cl_uart_rtos.h"
-#include "../vmc/vmc_api.h"
+#include "cl_config.h"
 #include "sysmon.h"
 
 int ospi_flash_init();
@@ -22,7 +22,6 @@ int RMGMT_Launch(void);
 int CL_MSG_launch(void);
 
 uart_rtos_handle_t uart_log;
-uart_rtos_handle_t uart_vmcsc_log;
 
 XSysMonPsv InstancePtr;
 XScuGic IntcInst;
@@ -48,8 +47,6 @@ void cl_system_pre_init(void)
 	/* Enable FreeRTOS Debug UART */
 	UART_RTOS_Debug_Enable(&uart_log);
 #endif
-
-	UART_VMC_SC_Enable(&uart_vmcsc_log);
 
 	if (XSysMonPsv_Init(&InstancePtr, &IntcInst) != XST_SUCCESS)
 	{

--- a/src/include/cl_config.h
+++ b/src/include/cl_config.h
@@ -1,0 +1,24 @@
+/******************************************************************************
+* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* SPDX-License-Identifier: MIT
+*******************************************************************************/
+
+#ifndef COMMON_CONFIG_H
+#define COMMON_CONFIG_H
+
+
+/**
+ * Uncomment for enabling CS2200 code.
+ * Make sure to build the board with CS2200 XSA and program it with CS2200 PDI.
+ */
+//#define PLATFORM_CS2200
+
+
+/* Uncomment for enabling VMC debug. */
+//#define VMC_DEBUG
+
+#ifdef VMC_DEBUG
+#define VMR_BUILD_VMC_ONLY
+#endif
+
+#endif

--- a/src/include/cl_gpio.h
+++ b/src/include/cl_gpio.h
@@ -1,0 +1,27 @@
+#ifndef INCLUDE_GPIO_H_
+#define INCLUDE_GPIO_H_
+
+#define GPIO_PIN_SPI_FLASH_CS				(9u)
+#define GPIO_PIN_FRU_EEPROM_WP				(12u)
+#define GPIO_PIN_VPD_EEPROM_WP				(13u)
+#define GPIO_PIN_VPD_EEPROM_SMBUS_SELECT	(25u)
+
+#define DEASSERTED 0
+#define ASSERTED 1
+
+#define LPD_GPIO_PORT	0
+#define PMC_GPIO_PORT	1
+
+#define OUTPUT_PIN	1
+#define INPUT_PIN	0
+
+u8 GPIOInit(void);
+
+
+
+u8 GPIOReadInput(uint32_t port, uint32_t theBit, uint32_t *value);
+u8 GPIOWriteOutput(uint32_t port, uint32_t theBit, uint32_t value);
+
+
+#endif
+

--- a/src/include/cl_i2c.h
+++ b/src/include/cl_i2c.h
@@ -9,6 +9,11 @@
 #define IIC_SCLK_RATE		100000
 
 #include "xil_types.h"
+#include "xstatus.h"
+
+#define PMC_I2C				(0u)
+#define LPD_I2C_0			(1u)
+#define LPD_I2C_1			(2u)
 
 u8 I2CInit(void);
 u8 i2c_send(u8 i2c_num, unsigned char i2c_addr, unsigned char * i2c_data, long int data_length);

--- a/src/include/cl_log.h
+++ b/src/include/cl_log.h
@@ -12,8 +12,6 @@
 
 #include "cl_version.h"
 
-//#define VMC_DEBUG
-
 /*
  * The pdMS_TO_TICKS is defined as (xTimeInMs * configTICKRATEHZ) / 1000
  * so the pdTICKS_TO_MS can be the opposite way

--- a/src/include/cl_version.h
+++ b/src/include/cl_version.h
@@ -10,3 +10,15 @@
  * 	VMR_GIT_BRANCH
  * 	VMR_GIT_BUILD_DATE
  */
+#ifndef _VMR_VERSION_
+#define _VMR_VERSION_
+#define VMR_GIT_HASH "30667820db9fa8e72482e7bc51d3bc02de94c17c"
+#define VMR_GIT_BRANCH "main"
+#define VMR_GIT_HASH_DATE "Mon, 24 Jan 2022 11:33:13 -0500"
+#endif
+#ifndef _VMR_VERSION_
+#define _VMR_VERSION_
+#define VMR_GIT_HASH "30667820db9fa8e72482e7bc51d3bc02de94c17c"
+#define VMR_GIT_BRANCH "main"
+#define VMR_GIT_HASH_DATE "Mon, 24 Jan 2022 11:33:13 -0500"
+#endif

--- a/src/vmc/MX25_CMD.h
+++ b/src/vmc/MX25_CMD.h
@@ -1,0 +1,108 @@
+/*
+ * COPYRIGHT (c) 2010-2014 MACRONIX INTERNATIONAL CO., LTD
+ * SPI Flash Low Level Driver (LLD) Sample Code
+ *
+ * SPI interface command hex code, type definition and function prototype.
+ *
+ * $Id: MX25_CMD.h,v 1.20 2013/11/08 01:41:48 modelqa Exp $
+ */
+#ifndef    __MX25_CMD_H__
+#define    __MX25_CMD_H__
+
+#include "cl_config.h"
+
+#ifdef PLATFORM_CS2200
+
+#include "xil_types.h"
+#include <stdbool.h>
+
+/*** MX25 series command hex code definition ***/
+//ID comands
+#define    FLASH_CMD_RDID      0x9F    //RDID (Read Identification)
+#define    FLASH_CMD_RES       0xAB    //RES (Read Electronic ID)
+#define    FLASH_CMD_REMS      0x90    //REMS (Read Electronic & Device ID)
+
+//Register comands
+#define    FLASH_CMD_WRSR      0x01    //WRSR (Write Status Register)
+#define    FLASH_CMD_RDSR      0x05    //RDSR (Read Status Register)
+#define    FLASH_CMD_WRSCUR    0x2F    //WRSCUR (Write Security Register)
+#define    FLASH_CMD_RDSCUR    0x2B    //RDSCUR (Read Security Register)
+#define    FLASH_CMD_RDCR      0x15    //RDCR (Read Configuration Register)
+
+//READ comands
+#define    FLASH_CMD_READ        0x03    //READ (1 x I/O)
+#define    FLASH_CMD_2READ       0xBB    //2READ (2 x I/O)
+#define    FLASH_CMD_4READ       0xEB    //4READ (4 x I/O)
+#define    FLASH_CMD_FASTREAD    0x0B    //FAST READ (Fast read data)
+#define    FLASH_CMD_DREAD       0x3B    //DREAD (1In/2 Out fast read)
+#define    FLASH_CMD_QREAD       0x6B    //QREAD (1In/4 Out fast read)
+#define    FLASH_CMD_RDSFDP      0x5A    //RDSFDP (Read SFDP)
+
+//Program comands
+#define    FLASH_CMD_WREN     0x06    //WREN (Write Enable)
+#define    FLASH_CMD_WRDI     0x04    //WRDI (Write Disable)
+#define    FLASH_CMD_PP       0x02    //PP (page program)
+#define    FLASH_CMD_4PP      0x38    //4PP (Quad page program)
+
+//Erase comands
+#define    FLASH_CMD_SE       0x20    //SE (Sector Erase)
+#define    FLASH_CMD_BE32K    0x52    //BE32K (Block Erase 32kb)
+#define    FLASH_CMD_BE       0xD8    //BE (Block Erase)
+#define    FLASH_CMD_CE       0x60    //CE (Chip Erase) hex code: 60 or C7
+
+//Mode setting comands
+#define    FLASH_CMD_DP       0xB9    //DP (Deep Power Down)
+#define    FLASH_CMD_RDP      0xAB    //RDP (Release form Deep Power Down)
+#define    FLASH_CMD_ENSO     0xB1    //ENSO (Enter Secured OTP)
+#define    FLASH_CMD_EXSO     0xC1    //EXSO  (Exit Secured OTP)
+#ifdef SBL_CMD_0x77
+#define    FLASH_CMD_SBL      0x77    //SBL (Set Burst Length) new: 0x77
+#else
+#define    FLASH_CMD_SBL      0xC0    //SBL (Set Burst Length) Old: 0xC0
+#endif
+
+//Reset comands
+#define    FLASH_CMD_RSTEN     0x66    //RSTEN (Reset Enable)
+#define    FLASH_CMD_RST       0x99    //RST (Reset Memory)
+
+//Security comands
+#ifdef LCR_CMD_0xDD_0xD5
+#else
+#endif
+
+//Suspend/Resume comands
+#define    FLASH_CMD_PGM_ERS_S    0xB0    //PGM/ERS Suspend (Suspends Program/Erase)
+#define    FLASH_CMD_PGM_ERS_R    0x30    //PGM/ERS Erase (Resumes Program/Erase)
+#define    FLASH_CMD_NOP          0x00    //NOP (No Operation)
+
+// Return Message
+typedef enum {
+    FlashOperationSuccess,
+    FlashWriteRegFailed,
+    FlashTimeOut,
+    FlashIsBusy,
+    FlashQuadNotEnable,
+    FlashAddressInvalid
+}ReturnMsg;
+
+// Flash status structure define
+struct sFlashStatus{
+    /* Mode Register:
+     * Bit  Description
+     * -------------------------
+     *  7   RYBY enable
+     *  6   Reserved
+     *  5   Reserved
+     *  4   Reserved
+     *  3   Reserved
+     *  2   Reserved
+     *  1   Parallel mode enable
+     *  0   QPI mode enable
+    */
+    u8    ModeReg;
+    bool     ArrangeOpt;
+};
+
+#endif
+
+#endif    /* __MX25_CMD_H__ */

--- a/src/vmc/sensors/inc/ina3221.h
+++ b/src/vmc/sensors/inc/ina3221.h
@@ -9,6 +9,8 @@
 
 #include "xil_types.h"
 
+#define INNA3221_ADDR 	(0x40)
+
 #define INA3221_CH1_SHUNT_VOLTAGE               0x01 
 #define INA3221_CH1_BUS_VOLTAGE                 0x02 
 

--- a/src/vmc/sensors/inc/isl68220.h
+++ b/src/vmc/sensors/inc/isl68220.h
@@ -1,0 +1,123 @@
+
+
+
+#ifndef ISL68220_H_
+#define ISL68220_H_
+ 
+#include <stdint.h>
+#include <stdbool.h>
+#include "xil_types.h"
+
+#define ISL68220_SLV_ADDR		(0x60)
+
+#define ISL68220_PAGE_REGISTER                  0x00
+#define ISL68220_OPERATION                      0x01
+#define ISL68220_ON_OFF_CONFIG_REGISTER         0x02
+
+//#define ISL68220_SELECT_VDDQ_0_1                0x00
+//#define ISL68220_SELECT_VDDQ_2_3                0x01
+//
+//#define VOUT_MARGIN_HIGH_MULTIPLIER             (float)(1.05)
+//#define VOUT_MARGIN_LOW_MULTIPLIER              (float)(0.95)
+//#define VOUT_OV_FAULT_LIMIT_MULTIPLIER          (float)(1.10)
+//#define VOUT_UV_FAULT_LIMIT_MULTIPLIER          (float)(0.90)
+
+//Commands for ISL68220 device.
+#define ISL68220_PAGE_REGISTER                  0x00
+#define ISL68220_OPERATION                      0x01
+#define ISL68220_SELECT_PAGE_VCCINT             0x00
+
+#define ISL68220_SELECT_PAGE_VCCINT_BRAM        0x01
+
+#define ISL68220_WRITE_PROTECT                  0x10
+
+#define ISL68220_VOUT_COMMAND                   0x21
+
+#define ISL68220_VOUT_MAX                       0x24
+#define ISL68220_VOUT_MARGIN_HIGH               0x25
+#define ISL68220_VOUT_MARGIN_LOW                0x26
+#define ISL68220_VOUT_MIN                       0x2B
+#define ISL68220_VOUT_OV_FAULT_LIMIT            0x40
+#define ISL68220_VOUT_UV_FAULT_LIMIT            0x44
+#define ISL68220_STATUS_WORD                    0x79
+#define ISL68220_OUTPUT_VOLTAGE_REGISTER        0x8B
+#define ISL68220_OUTPUT_CURRENT_REGISTER    	0x8C
+#define ISL68220_READ_POWERSTAGE_TEMPERATURE    0x8D
+#define ISL68220_READ_INTERNAL_TEMPERATURE   	0x8E
+#define ISL68220_READ_PIN_TEMPERATURE    		0x8F
+#define ISL68220_RESTORE_CONFIG_REGISTER        0xF2
+
+
+
+// ID of VCCINT config settings.
+enum ISL68220_CONFIG{
+	CONFIG_R_0,
+	CONFIG_R_162,
+	CONFIG_R_316,
+	CONFIG_R_487,
+	CONFIG_R_681,
+	CONFIG_R_887,
+	CONFIG_R_1130,
+	CONFIG_R_1370,
+	CONFIG_R_1650,
+	CONFIG_R_1960,
+	CONFIG_R_2320,
+	CONFIG_R_2670,
+	CONFIG_R_3090,
+	CONFIG_R_3570,
+	CONFIG_R_4120,
+	CONFIG_R_4640,
+};
+
+/**
+* @brief This function is used to read any register on the ISL68220
+* @param[in] i2c                - I2C Handle
+* @param[in] SlaveAddr          - Slave address of ISL68220
+* @param[in] register_address   - Register address to be read
+* @param[out]register_content   - Register content
+*
+* @return    true    - Success
+* @return    false   - Failed
+*
+* @note      None
+**
+******************************************************************************/
+bool ISL68220_set_vccint_config(u8 busnum, uint8_t SlaveAddr, uint8_t vccint_opt);
+
+bool ISL68220_read_one_byte_register(u8 busnum, uint8_t SlaveAddr, uint8_t register_address, uint8_t *register_content);
+
+bool ISL68220_read_register(u8 busnum, uint8_t SlaveAddr, uint8_t register_address, uint8_t *register_content);
+
+bool ISL68220_VOUT_write(u8 busnum, uint8_t slave_addr, uint8_t *register_content);
+
+bool ISL68220_VOUT_MARGIN_HIGH_write(u8 busnum, uint8_t slave_addr, uint8_t *register_content);
+
+bool ISL68220_VOUT_OV_FAULT_LIMIT_write(u8 busnum, uint8_t slave_addr, uint8_t *register_content);
+
+bool ISL68220_APPLY_SETTINGS_write(u8 busnum, uint8_t slave_addr, uint8_t *register_content);
+
+bool ISL68220_VOUT_UV_FAULT_LIMIT_write(u8 busnum, uint8_t slave_addr, uint8_t *register_content);
+
+bool ISL68220_VOUT_MARGIN_LOW_write(u8 busnum, uint8_t slave_addr, uint8_t *register_content);
+
+bool ISL68220_set_vout_max(u8 busnum, uint8_t slave_addr);
+
+bool ISL68220_set_vout_min(u8 busnum, uint8_t slave_addr);
+
+bool ISL68220_write_register(u8 busnum, uint8_t SlaveAddr, uint8_t register_address, uint8_t *register_content);
+
+bool ISL68220_Read_VCCINT_Voltage(u8 busnum, uint8_t SlaveAddr, uint16_t *RegisterValue);
+
+bool ISL68220_Read_VCCINT_Current(u8 busnum,uint8_t SlaveAddr, float *RegisterValue);
+
+bool ISL68220_Read_VCCINT_BRAM_Voltage(u8 busnum, uint8_t SlaveAddr, uint16_t *RegisterValue);
+
+bool ISL68220_Read_VCCINT_BRAM_Current(u8 busnum,uint8_t SlaveAddr, float *RegisterValue);
+
+bool ISL68220_Read_VCCINT_Temperature(u8 busnum,uint8_t SlaveAddr, float *RegisterValue);
+
+bool ISL68220_Read_VCCINT_BRAM_Temperature(u8 busnum,uint8_t SlaveAddr, float *RegisterValue);
+
+bool ISL68220_Read_Temperature(u8 busnum,uint8_t SlaveAddr, u8 tempReg, float *RegisterValue);
+
+#endif /* ISL68220_H_ */

--- a/src/vmc/sensors/inc/lm75.h
+++ b/src/vmc/sensors/inc/lm75.h
@@ -3,4 +3,12 @@
  *   * * SPDX-License-Identifier: MIT
  *    * *******************************************************************************/
 
+#ifndef LM75_H_
+#define LM75_H_
+
+#define TEMP_LM75_0x48	(0x48)
+#define TEMP_LM75_0x4A	(0x4A)
+
 u8 LM75_ReadTemperature(u8 i2c_num, u8 slaveAddr, s32 *temperatureValue);
+
+#endif

--- a/src/vmc/sensors/inc/m24128.h
+++ b/src/vmc/sensors/inc/m24128.h
@@ -54,4 +54,4 @@
 #define EEPROM_OEMID_SIZE_OFFSET         0x6C00
 #define EEPROM_OEMID_SIZE                4
 
-u8 M24C128_ReadByte(u8 i2c_num, u8 slaveAddr, u16 *AddressOffset,u8 *RegisterValue);
+u8 M24128_ReadByte(u8 i2c_num, u8 slaveAddr, u16 *AddressOffset,u8 *RegisterValue);

--- a/src/vmc/sensors/src/isl68220.c
+++ b/src/vmc/sensors/src/isl68220.c
@@ -1,0 +1,705 @@
+/******************************************************************************
+* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* SPDX-License-Identifier: MIT
+*******************************************************************************/
+
+#include "cl_i2c.h"
+#include "unistd.h"
+#include "../inc/isl68220.h"
+
+#include "xil_types.h"
+#include "../../vmc_api.h"
+
+
+#define MAX_VOUT_MAX_DIRECT_VAL     0x076C
+#define MIN_VOUT_MIN_DIRECT_VAL     0x0000
+
+#define MAX_RETRY       3
+
+
+/*----------------------------------------------------------------------------
+ * pmbus_init_vccint_config  Set the VCCINT regulator to the configuration
+ *                           whose ID is passed in
+ *
+ * Parameters:     ID of VCCINT config setting.
+ * Return:         none
+ *
+ * Disable the VCCINT regulator and initiate a config recall. Then enable
+ * the regulator. It is assumed the configuration passed in is valid for
+ * the currently plugged in AUXilary power connectors.
+ *
+ * This only applies to the V350 board. All other boards to date configure
+ * VCCINT without firmware assist.
+ *---------------------------------------------------------------------------*/
+// Change the VCCINT regulator to use the configuration whose ID is passed in.
+bool ISL68220_set_vccint_config(u8 busnum, u8 SlaveAddr, u8 vccint_opt)
+{
+    u8  txbuf[2] = {0};
+    bool  status = XST_FAILURE;
+
+    // u8  operation_page0_save; // needed?
+    // u8  operation_page1_save; // needed?
+
+    /*  Change VCCINT regulator
+     *
+     *  Procedure: Disable each output (2) by writing to OPERATION reg
+     *             Change configuration by writing to RESTORE_CONFIG reg
+     *               (Restore of config will default to output enabled or
+     *                disabled based on config setting, so no need to restore
+     *                OPERATION reg after restore.)
+     */
+
+    // Set Page to Both Pages: PAGE          (0x00) = 0xff
+    txbuf[0] = 0xFF;
+
+    status = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &txbuf[0]);
+    if (status != XST_SUCCESS)
+    {
+        return false;
+    }
+    // Disable VCCINT and VCC1v2: OPERATION        (0x01) &= 0x3F
+
+ /*   // Read OPERATION Reg
+    txbuf[0] = 0x01;            // Register to read: OPERATION
+                                // txbuf[1] not used in this case
+    //function puts content of OPERATION reg in txbuf[0]
+    status = ISL68220_read_register(busnum, SlaveAddr, ISL68220_OPERATION_REGISTER, &txbuf[0]);
+    if (status == XST_FAILURE)
+    {
+        return false;
+    }
+*/
+
+    /*
+    // Restore config ID: RESTORE_CONFIG (F2h) = vccint_opt
+    // Change configuration by sending the config ID code (assumed to be 0-F)
+    // to the RESTORE_CONFIG register.
+    status = ISL68220_write_register(busnum, SlaveAddr, ISL68220_RESTORE_CONFIG_REGISTER, &vccint_opt);
+    if (status != XST_SUCCESS)
+    {
+        return false;
+    }
+    */
+/*
+    // Set Page to VCCINT and VCC1v2: Page          (0x00)  = 0xff
+    // Set Page to Both Pages: PAGE          (0x00) = 0xff
+    txbuf[0] = 0xFF;            // Register to write: PAGE
+    status = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &txbuf[0]);
+    if (status == false)
+    {
+        return false;
+    }
+
+    // Enable VCCINT and VCC1v2: OPERATION          (0x08) |= 0x80
+    // Write OPERATION reg to enable voltage for both pages (VCCINT & VCC1v2)
+    txbuf[0] = 0x88; // Turn on bit 7: On in OPERATION reg
+
+    status = ISL68220_write_register(busnum, SlaveAddr, ISL68220_OPERATION_REGISTER, &txbuf[0]);
+    if (status == false)
+    {
+        return false;
+    }
+*/
+    return status;
+}
+
+bool ISL68220_read_one_byte_register(u8 busnum, u8 SlaveAddr, u8 register_address, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 wbuf[8];
+    u8 rbuf[8];
+
+    wbuf[0] = register_address;
+    rbuf[0] = 0;
+
+    do
+    {
+        Status = i2c_send_rs_recv(busnum, SlaveAddr, (u8 *)wbuf, 1, (u8 *)&rbuf[0], 1);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading one byte register from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+
+bool ISL68220_read_register(u8 busnum, u8 SlaveAddr, u8 register_address, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 wbuf[8];
+	//u8 rbuf[8] = {0};
+
+	wbuf[0] = register_address;
+
+    do
+    {
+        Status = i2c_send_rs_recv(busnum, SlaveAddr, (u8 *)wbuf, 1, register_content, 2);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading two byte register from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+bool ISL68220_VOUT_write(u8 busnum, u8 slave_addr, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[3] = {0};
+    write_data[0] = ISL68220_VOUT_COMMAND;
+    memcpy(&write_data[1], register_content, 2);
+
+    do
+    {
+        Status = i2c_send(busnum, slave_addr, write_data, 3);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing VOUT to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+bool ISL68220_VOUT_MARGIN_HIGH_write(u8 busnum, u8 slave_addr, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[3] = {0};
+    write_data[0] = ISL68220_VOUT_MARGIN_HIGH;
+    memcpy(&write_data[1], register_content, 2);
+
+    do
+    {
+        Status = i2c_send(busnum, slave_addr, write_data, 3);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing VOUT_MARGIN to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+bool ISL68220_VOUT_OV_FAULT_LIMIT_write(u8 busnum, u8 slave_addr, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[3] = {0};
+    write_data[0] = ISL68220_VOUT_OV_FAULT_LIMIT;
+    memcpy(&write_data[1], register_content, 2);
+
+    do
+    {
+        Status = i2c_send(busnum, slave_addr, write_data, 3);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing VOUT_OV_FAULT_LIMIT to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+bool ISL68220_VOUT_MARGIN_LOW_write(u8 busnum, u8 slave_addr, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[3] = {0};
+    write_data[0] = ISL68220_VOUT_MARGIN_LOW;
+    memcpy(&write_data[1], register_content, 2);
+
+    do
+    {
+        Status = i2c_send(busnum, slave_addr, write_data, 3);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing VOUT_MARGIN_LOW to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+bool ISL68220_VOUT_UV_FAULT_LIMIT_write(u8 busnum, u8 slave_addr, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[3] = {0};
+    write_data[0] = ISL68220_VOUT_UV_FAULT_LIMIT;
+    memcpy(&write_data[1], register_content, 2);
+
+    do
+    {
+        Status = i2c_send(busnum, slave_addr, write_data, 3);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing VOUT_UV_FAULT_LIMIT to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+
+bool ISL68220_set_vout_max(u8 busnum, u8 slave_addr)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[3] = {0};
+    write_data[0] = ISL68220_VOUT_MAX;
+
+    //LSB followed by MSB
+    write_data[1] = (u8)(MAX_VOUT_MAX_DIRECT_VAL);
+    write_data[2] = (u8)(MAX_VOUT_MAX_DIRECT_VAL>>8);
+
+    do
+    {
+        Status = i2c_send(busnum, slave_addr, write_data, 3);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing ISL68220_set_vout_max to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+bool ISL68220_set_vout_min(u8 busnum, u8 slave_addr)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[3] = {0};
+    write_data[0] = ISL68220_VOUT_MIN;
+
+    //LSB followed by MSB
+    write_data[1] = (u8)(MIN_VOUT_MIN_DIRECT_VAL);
+    write_data[2] = (u8)(MIN_VOUT_MIN_DIRECT_VAL>>8);
+
+    do
+    {
+        Status = i2c_send(busnum, slave_addr, write_data, 3);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing ISL68220_set_vout_min to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+bool ISL68220_write_register(u8 busnum, u8 SlaveAddr, u8 register_address, u8 *register_content)
+{
+    u8 retries = MAX_RETRY;
+    bool Status = XST_FAILURE;
+
+    u8 write_data[2]= {0};
+    write_data[0] = register_address;
+    write_data[1] = *register_content;
+
+    do
+    {
+        Status = i2c_send(busnum, SlaveAddr, (u8 *)write_data, 2);
+        retries--;
+        if(Status != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing ISL68220_set_vout_min to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while((Status != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    return Status;
+}
+
+bool ISL68220_Read_VCCINT_Voltage(u8 busnum, u8 SlaveAddr, u16 *RegisterValue)
+{
+    u8 retries = MAX_RETRY;
+    bool RetVal = XST_FAILURE;
+    u8 temp[2] = {0, 0};
+    u16 temp_voltage = 0;
+    u8 reg_address = ISL68220_SELECT_PAGE_VCCINT;
+
+    do
+    {
+        RetVal = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &reg_address);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing PAGE REGISTER to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    do
+    {
+        RetVal = ISL68220_read_register(busnum, SlaveAddr, ISL68220_OUTPUT_VOLTAGE_REGISTER, temp);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading VCCINT Voltage from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+   // LOG_INFO_MSG("register value %x %x \r\n",temp[0],temp[1]);
+
+    temp_voltage = (temp[1] << 8) | temp[0];
+    *RegisterValue = temp_voltage;
+
+    return RetVal;
+}
+
+bool ISL68220_Read_VCCINT_Current(u8 busnum,u8 SlaveAddr, float *RegisterValue)
+{
+    u8 retries = MAX_RETRY;
+    bool RetVal = XST_FAILURE;
+    u8 temp[2] = {0, 0};
+    u16 temp_current = 0;
+    u8 reg_address = ISL68220_SELECT_PAGE_VCCINT;
+
+    do
+    {
+        RetVal = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &reg_address);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing PAGE REGISTER to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if(RetVal != XST_SUCCESS)
+
+    {
+        return RetVal;
+    }
+
+    do
+    {
+        RetVal = ISL68220_read_register(busnum, SlaveAddr, ISL68220_OUTPUT_CURRENT_REGISTER, temp);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading VCCINT Current from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if(RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    temp_current = (temp[1] << 8) | temp[0];
+    *RegisterValue = (float)temp_current/10;
+
+    return RetVal;
+}
+
+bool ISL68220_Read_VCCINT_BRAM_Voltage(u8 busnum, u8 SlaveAddr, u16 *RegisterValue)
+{
+    u8 retries = MAX_RETRY;
+    bool RetVal = XST_FAILURE;
+    u8 temp[2] = {0, 0};
+    u16 temp_voltage = 0;
+    u8 reg_address = ISL68220_SELECT_PAGE_VCCINT_BRAM;
+
+    do
+    {
+        RetVal = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &reg_address);
+        retries--;
+        if (RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing PAGE REGISTER to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    do
+    {
+        RetVal = ISL68220_read_register(busnum, SlaveAddr, ISL68220_OUTPUT_VOLTAGE_REGISTER, temp);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading VCCINT BRAM voltage from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    temp_voltage = (temp[1] << 8) | temp[0];
+    *RegisterValue = temp_voltage;
+
+    return RetVal;
+}
+
+bool ISL68220_Read_VCCINT_BRAM_Current(u8 busnum,u8 SlaveAddr, float *RegisterValue)
+{
+    u8 retries = MAX_RETRY;
+    bool RetVal = XST_FAILURE;
+    u8 temp[2] = {0, 0};
+    u16 temp_current = 0;
+    u8 reg_address = ISL68220_SELECT_PAGE_VCCINT_BRAM;
+
+    do
+    {
+        RetVal = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &reg_address);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing PAGE REGISTER to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    do
+    {
+        RetVal = ISL68220_read_register(busnum, SlaveAddr, ISL68220_OUTPUT_CURRENT_REGISTER, temp);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading VCCINT BRAM current from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    temp_current = (temp[1] << 8) | temp[0];
+    *RegisterValue = (float)temp_current/10;
+
+    return RetVal;
+}
+
+bool ISL68220_Read_VCCINT_Temperature(u8 busnum,u8 SlaveAddr, float *RegisterValue)
+{
+    u8 retries = MAX_RETRY;
+    bool RetVal = XST_FAILURE;
+    u8 temp[2] = {0, 0};
+    int16_t temperature = 0;
+
+    u8 reg_address = ISL68220_SELECT_PAGE_VCCINT;
+
+
+    do
+    {
+        RetVal = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &reg_address);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing PAGE REGISTER to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    do
+    {
+        RetVal = ISL68220_read_register(busnum, SlaveAddr, ISL68220_READ_POWERSTAGE_TEMPERATURE, temp);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading VCCINTTemperature from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+	temperature = (temp[1] << 8) | temp[0];
+
+    if (temperature > 200 || temperature < -100)    /* temp by MDH because returning all FF's after power on */
+    {
+        RetVal = XST_FAILURE;
+        temperature = 25;
+    }
+
+    *RegisterValue = (float)temperature;
+
+    return RetVal;
+}
+
+bool ISL68220_Read_VCCINT_BRAM_Temperature(u8 busnum,u8 SlaveAddr, float *RegisterValue)
+{
+    u8 retries = MAX_RETRY;
+    bool RetVal = XST_FAILURE;
+    u8 temp[2] = {0, 0};
+    u16 temperature = 0;
+
+    u8 reg_address = ISL68220_SELECT_PAGE_VCCINT_BRAM;
+
+
+    do
+    {
+        RetVal = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &reg_address);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing PAGE Register to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    do
+    {
+        RetVal = ISL68220_read_register(busnum, SlaveAddr, ISL68220_READ_POWERSTAGE_TEMPERATURE, temp);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading VCCINT Temperature from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    temperature = (temp[1] << 8) | temp[0];
+    *RegisterValue = (float)temperature;
+
+    return RetVal;
+}
+
+bool ISL68220_Read_Temperature(u8 busnum,u8 SlaveAddr,u8 tempReg, float *RegisterValue)
+{
+    u8 retries = MAX_RETRY;
+    bool RetVal = XST_FAILURE;
+    u8 temp[2] = {0, 0};
+    int16_t temperature = 0;
+
+    u8 reg_address = ISL68220_SELECT_PAGE_VCCINT;
+
+
+    do
+    {
+        RetVal = ISL68220_write_register(busnum, SlaveAddr, ISL68220_PAGE_REGISTER, &reg_address);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in writing PAGE REGISTER to ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+
+    do
+    {
+        RetVal = ISL68220_read_register(busnum, SlaveAddr, tempReg, temp);
+        retries--;
+        if ( RetVal != XST_SUCCESS)
+        {
+            VMC_ERR("\r\nError in reading VCCINTTemperature from ISL68220.. Retries  Left: %d\r\n", retries);
+        }
+    }while(( RetVal != XST_SUCCESS)&&(retries!=0));
+    retries = MAX_RETRY;
+
+    //If the value returned is false, return.
+    if( RetVal != XST_SUCCESS)
+    {
+        return RetVal;
+    }
+	temperature = (temp[1] << 8) | temp[0];
+
+    if (temperature > 200 || temperature < -100)    /* temp by MDH because returning all FF's after power on */
+    {
+        RetVal = XST_FAILURE;
+        temperature = 25;
+    }
+
+    *RegisterValue = (float)temperature;
+
+    return RetVal;
+}
+
+
+

--- a/src/vmc/sensors/src/lm75.c
+++ b/src/vmc/sensors/src/lm75.c
@@ -8,7 +8,7 @@
 
 u8 LM75_ReadTemperature(u8 i2c_num, u8 slaveAddr, s32 *temperatureValue)
 {
-    u8 status = 0;
+    u8 status = XST_FAILURE;
     s32 TempHexVal = 0;
     u8 i2c_read_buff[2] = {0};
     u8 i2c_read_len = 2;
@@ -17,31 +17,31 @@ u8 LM75_ReadTemperature(u8 i2c_num, u8 slaveAddr, s32 *temperatureValue)
     i2c_write_buff[0] = 0x00;
     
     status = i2c_send_rs_recv(i2c_num, slaveAddr, &i2c_write_buff[0], 1, &i2c_read_buff[0], i2c_read_len);
-    if(0 == status)
+    if(XST_SUCCESS == status)
     {
-	/* only 11 MSB should be used , 5 LSB bits are zero and ignored  */
-	TempHexVal = i2c_read_buff[1] | (i2c_read_buff[0] << 8);
-	TempHexVal = TempHexVal >> 5;
+		/* only 11 MSB should be used , 5 LSB bits are zero and ignored  */
+		TempHexVal = i2c_read_buff[1] | (i2c_read_buff[0] << 8);
+		TempHexVal = TempHexVal >> 5;
 
-	/* The 11th bit is the sign bit ,
-  	 *
-  	 * For +ve temperature:
-  	 * TempHexVal * 0.125 = Actual Temperature
-  	 *
-  	 * For -ve Temperature:
-  	 * -(two's compliment of TempHexVal) * 0.125 = Actual Temperature
-  	 */
+		/* The 11th bit is the sign bit ,
+		 *
+		 * For +ve temperature:
+		 * TempHexVal * 0.125 = Actual Temperature
+		 *
+		 * For -ve Temperature:
+		 * -(two's compliment of TempHexVal) * 0.125 = Actual Temperature
+		 */
 
-	if(TempHexVal < 0x3FF) 
-	{
-	    /* Positive Temperature */
-	    *temperatureValue = (int)TempHexVal * 0.125;
-	}
-	else 
-	{
-	    /* Negative Temperature */
-	    TempHexVal = TempHexVal & 0x7FF;
-	    *temperatureValue = (int)(0x800 - TempHexVal ) * 0.125 * (-1);
+		if(TempHexVal < 0x3FF)
+		{
+			/* Positive Temperature */
+			*temperatureValue = (int)TempHexVal * 0.125;
+		}
+		else
+		{
+			/* Negative Temperature */
+			TempHexVal = TempHexVal & 0x7FF;
+			*temperatureValue = (int)(0x800 - TempHexVal ) * 0.125 * (-1);
 	}
     }
 

--- a/src/vmc/sensors/src/m24128.c
+++ b/src/vmc/sensors/src/m24128.c
@@ -6,9 +6,9 @@
 #include "cl_uart_rtos.h"
 #include "cl_log.h"
 #include "cl_i2c.h"
-#include "../inc/m24c128.h"
+#include "../inc/m24128.h"
 
-u8 M24C128_ReadByte(u8 i2c_num, u8 slaveAddr, u16 *AddressOffset,u8 *RegisterValue)
+u8 M24128_ReadByte(u8 i2c_num, u8 slaveAddr, u16 *AddressOffset,u8 *RegisterValue)
 {
 	u8 status = 0;
 	status = i2c_send_rs_recv(i2c_num, slaveAddr, (u8 *)AddressOffset, 2, RegisterValue, 1);

--- a/src/vmc/spi_flash.c
+++ b/src/vmc/spi_flash.c
@@ -1,0 +1,325 @@
+/******************************************************************************
+* Copyright (C) 2010 - 2021 Xilinx, Inc.  All rights reserved.
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+/***************************** Include Files *********************************/
+
+#include "MX25_CMD.h"
+
+#ifdef PLATFORM_CS2200
+
+#include "xparameters.h"	/* SDK generated parameters */
+#include "xplatform_info.h"
+#include "xspips.h"		/* SPI device driver */
+#include "vmc_api.h"
+
+/************************** Constant Definitions *****************************/
+
+/*
+ * The following constants map to the XPAR parameters created in the
+ * xparameters.h file. They are defined here such that a user can easily
+ * change all the needed parameters in one place.
+ */
+#define SPI_FLASH_DEVICE_ID		XPAR_XSPIPS_0_DEVICE_ID
+
+
+/*
+ * The following constants define the offsets within a FlashBuffer data
+ * type for each kind of data.  Note that the read data offset is not the
+ * same as the write data because the SPI driver is designed to allow full
+ * duplex transfers such that the number of bytes received is the number
+ * sent and received.
+ */
+#define COMMAND_OFFSET		0 /* Flash instruction */
+#define ADDRESS_1_OFFSET	1 /* MSB byte of address to read or write */
+#define ADDRESS_2_OFFSET	2 /* Middle byte of address to read or write */
+#define ADDRESS_3_OFFSET	3 /* LSB byte of address to read or write */
+#define DATA_OFFSET			4 /* Start of Data for Read/Write */
+#define DUMMY_SIZE			1 /* Number of dummy bytes for fast read */
+#define RD_ID_SIZE			4 /* Read ID command + 3 bytes ID response */
+
+/*
+ * The following constants specify the extra bytes which are sent to the
+ * flash on the SPI interface, that are not data, but control information
+ * which includes the command and address
+ */
+#define OVERHEAD_SIZE		4
+
+#define UNIQUE_VALUE		0x05
+
+/*
+ * The following constants specify the max amount of data and the size of the
+ * the buffer required to hold the data and overhead to transfer the data to
+ * and from the flash.
+ */
+#define MAX_DATA		1024*1024
+
+/*
+ * The following constant defines the slave select signal that is used to
+ * to select the flash device on the SPI bus, this signal is typically
+ * connected to the chip select of the device
+ */
+#define FLASH_SPI_SELECT_1	0x01
+#define FLASH_SPI_SELECT_0	0x00
+
+/**************************** Type Definitions *******************************/
+
+/***************** Macros (Inline Functions) Definitions *********************/
+
+/************************** Function Prototypes ******************************/
+
+s32 SPI_Flash_Config(void);
+
+static void SPI_Flash_Erase(XSpiPs *SpiPtr);
+
+static void SPI_Flash_Write(XSpiPs *SpiPtr, u32 Address, u32 ByteCount);
+
+static void SPI_Flash_Read(XSpiPs *SpiPtr, u32 Address, u32 ByteCount);
+
+
+static int SPI_Flash_Read_ID(XSpiPs *SpiInstance);
+
+/************************** Variable Definitions *****************************/
+
+
+XSpiPs SpiFlashInstance;
+
+
+/*
+ * Write Address Location in Serial Flash.
+ */
+static int TestAddress;
+
+/*
+ * The following variables are used to read and write to the eeprom and they
+ * are global to avoid having large buffers on the stack
+ */
+u8 ReadBuff[MAX_DATA + DATA_OFFSET + DUMMY_SIZE];
+u8 WriteBuffer[MAX_DATA + DATA_OFFSET];
+
+
+/*****************************************************************************/
+/**
+*
+* The purpose of this function is to illustrate how to use the XSpiPs
+* device driver in polled mode. This function writes and reads data
+* from a serial flash.
+*
+* @param	SpiInstancePtr is a pointer to the SPI driver instance to use.
+*
+* @param	SpiDeviceId is the Instance Id of SPI in the system.
+*
+* @return
+*		- XST_SUCCESS if successful
+*		- XST_FAILURE if not successful
+*
+* @note
+*
+* If the device slave select is not correct and the device is not responding
+* on bus it will read a status of 0xFF for the status register as the bus
+* is pulled up.
+*
+*****************************************************************************/
+static int SPI_Flash_Init(XSpiPs *SpiInstancePtr,
+			 u16 SpiDeviceId)
+{
+	int Status;
+	u8 *BufferPtr;
+	u8 UniqueValue;
+	u32 Count;
+	u32 MaxSize = MAX_DATA;
+	u32 ChipSelect = FLASH_SPI_SELECT_1;
+	XSpiPs_Config *SpiConfig;
+	u32 Platform;
+
+	Platform = XGetPlatform_Info();
+	if ((Platform == XPLAT_ZYNQ_ULTRA_MP) || (Platform == XPLAT_VERSAL)) {
+		MaxSize = 1024 * 10;
+		ChipSelect = FLASH_SPI_SELECT_0;	/* Device is on CS 0 */
+	}
+
+	/*
+	 * Initialize the SPI driver so that it's ready to use
+	 */
+	SpiConfig = XSpiPs_LookupConfig(SpiDeviceId);
+	if (NULL == SpiConfig) {
+		return XST_FAILURE;
+	}
+
+	Status = XSpiPs_CfgInitialize(SpiInstancePtr, SpiConfig,
+					SpiConfig->BaseAddress);
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+
+	/*
+	 * Perform a self-test to check hardware build
+	 */
+	Status = XSpiPs_SelfTest(SpiInstancePtr);
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+
+	/*
+	 * Set the SPI device as a master with manual start and manual
+	 * chip select mode options
+	 */
+	XSpiPs_SetOptions(SpiInstancePtr, XSPIPS_MANUAL_START_OPTION | \
+			XSPIPS_MASTER_OPTION | XSPIPS_FORCE_SSELECT_OPTION);
+
+
+	/*
+	 * Set the SPI device pre-scalar to divide by 8
+	 */
+	XSpiPs_SetClkPrescaler(SpiInstancePtr, XSPIPS_CLK_PRESCALE_8);
+
+	/*
+	 * Set the flash chip select
+	 */
+	XSpiPs_SetSlaveSelect(SpiInstancePtr, ChipSelect);
+
+	/*
+	 * Read the flash Id
+	 */
+	Status = SPI_Flash_Read_ID(SpiInstancePtr);
+	if (Status != XST_SUCCESS) {
+		VMC_ERR("SPI Flash Read ID Failed\r\n");
+		return XST_FAILURE;
+	}
+
+	VMC_LOG("Flash ID Done!");
+
+	return XST_SUCCESS;
+}
+
+/******************************************************************************
+*
+*
+* This function writes to the desired address in serial flash connected to
+* the SPI interface.
+*
+* @param	SpiPtr is a pointer to the SPI driver instance to use.
+* @param	Address contains the address to write data to in the flash.
+* @param	ByteCount contains the number of bytes to write.
+*
+* @return	None.
+*
+* @note		None.
+*
+******************************************************************************/
+static void SPI_Flash_Write(XSpiPs *SpiPtr, u32 Address, u32 ByteCount)
+{
+
+
+}
+
+/******************************************************************************
+*
+* This function reads from the  serial flash connected to the
+* SPI interface.
+*
+* @param	SpiPtr is a pointer to the SPI driver instance to use.
+* @param	Address contains the address to read data from in the flash.
+* @param	ByteCount contains the number of bytes to read.
+* @param	Command is the command used to read data from the flash. SPI
+*		device supports one of the Read, Fast Read commands to read
+*		data from the flash.
+*
+* @return	None.
+*
+* @note		None.
+*
+******************************************************************************/
+static void SPI_Flash_Read(XSpiPs *SpiPtr, u32 Address, u32 ByteCount)
+{
+	/* TODO: The following is not tested.*/
+
+//	/*
+//	 * Setup the read command with the specified address and data for the
+//	 * flash
+//	 */
+//	WriteBuffer[COMMAND_OFFSET]   = FLASH_CMD_READ;
+//	WriteBuffer[ADDRESS_1_OFFSET] = (u8)((Address & 0xFF0000) >> 16);
+//	WriteBuffer[ADDRESS_2_OFFSET] = (u8)((Address & 0xFF00) >> 8);
+//	WriteBuffer[ADDRESS_3_OFFSET] = (u8)(Address & 0xFF);
+//
+//	XSpiPs_PolledTransfer(SpiPtr, WriteBuffer, ReadBuff,
+//			  ByteCount + OVERHEAD_SIZE);
+
+}
+
+
+/******************************************************************************
+*
+* This function reads serial flash ID connected to the SPI interface.
+*
+* @param	None.
+*
+* @return
+*		- XST_SUCCESS if successful
+*		- XST_FAILURE if not successful
+*
+* @note		None.
+*
+******************************************************************************/
+static int SPI_Flash_Read_ID(XSpiPs *SpiInstance)
+{
+
+	u8 Index;
+	int Status;
+	u8 ByteCount = 4;
+	u8 SendBuffer[8];
+	u8 RecvBuffer[4] = {0};
+
+	SendBuffer[0] = FLASH_CMD_RDID;
+	SendBuffer[1] = 0;
+	SendBuffer[2] = 0;
+	SendBuffer[3] = 0;
+
+	for(Index=0; Index < ByteCount; Index++) {
+		SendBuffer[4 + Index] = 0x00;
+	}
+
+	Status = XSpiPs_PolledTransfer(SpiInstance, SendBuffer, RecvBuffer,
+			 (ByteCount));
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+
+
+	VMC_LOG("\n\r");
+	VMC_PRNT("SPI Flash ID:");
+	for(Index = 1; Index < ByteCount; Index++) {
+		VMC_PRNT(" 0x%0X ", RecvBuffer[Index]);
+	}
+
+
+	return XST_SUCCESS;
+}
+
+/******************************************************************************
+*
+*
+* This function erases the sectors in the  serial flash connected to the
+* SPI interface.
+*
+* @param	SpiPtr is a pointer to the SPI driver instance to use.
+*
+* @return	None.
+*
+* @note		None.
+*
+******************************************************************************/
+static void SPI_Flash_Erase(XSpiPs *SpiPtr)
+{
+
+}
+
+
+s32 SPI_Flash_Config(void)
+{
+	return SPI_Flash_Init(&SpiFlashInstance,SPI_FLASH_DEVICE_ID);
+}
+
+#endif

--- a/src/vmc/vmc_api.h
+++ b/src/vmc/vmc_api.h
@@ -18,17 +18,15 @@
 #include "xil_types.h"
 
 #include "cl_log.h"
-#include "cl_main.h"
+#include "cl_config.h"
 #include "cl_io.h"
-
-/* Uncomment for enabling VMC debug. */
-//#define VMC_DEBUG
 
 #define	VMC_STRING	"VMC"
 
 #ifdef VMC_DEBUG
 #warning "When enabled RPU UART RX has conflic with APU UART so need to disable XRT code (RMGMT_Launch and cl_msg_service_launch)."
-#define VMR_BUILD_VMC_ONLY
+
+#define VMC_DEMO
 
 #define VMC_DMO(fmt, arg...) 		\
 	VMC_Printf(__FILENAME__, __LINE__, VMC_LOG_LEVEL_DEMO_MENU, fmt,##arg)
@@ -198,5 +196,14 @@ void EepromDump(void);
 **
 ******************************************************************************/
 u8 Versal_EEPROM_ReadBoardIno(void);
+
+#ifdef PLATFORM_CS2200
+
+void Temp_LM75_Display(void);
+void INA3221_Display(void);
+void ISL68220_Display(void);
+void VPD_EEPROM_ReadBoardIno(void);
+#endif
+
 
 #endif /* INC_VMC_API_H_ */

--- a/src/vmc/vmc_asdm.c
+++ b/src/vmc/vmc_asdm.c
@@ -3,6 +3,7 @@
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 
+#include "cl_config.h"
 #include "vmc_sensors.h"
 #include "vmc_asdm.h"
 #include "cl_log.h"
@@ -27,7 +28,12 @@ extern s8 Temperature_Read_QSFP(snsrRead_t *snsrData);
 Asdm_Header_t asdmHeaderInfo[] = {
     /* Record Type	| Hdr Version | Record Count | NumBytes */
     {BoardInfoSDR ,  	 	0x1  ,		 0x2, 		0x7f},
+#ifdef PLATFORM_CS2200
+	{TemperatureSDR , 		0x1  ,		 0x3,		0x7f},
+#else
     {TemperatureSDR , 		0x1  ,		 0x6,		0x7f},
+#endif
+
 };
 
 #define MAX_SDR_REPO 	(sizeof(asdmHeaderInfo)/sizeof(asdmHeaderInfo[0]))
@@ -98,6 +104,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .sampleCount = 0x1,
 	    .monitorFunc = &Temperature_Read_Outlet,
 	},
+#ifndef PLATFORM_CS2200
 	{
 	    .repoType = TemperatureSDR,
 	    .sensorName = "Board Temp\0",
@@ -112,6 +119,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .sampleCount = 0x1,
 	    .monitorFunc = &Temperature_Read_Board,
 	},
+#endif
 	/*{
 	    .repoType = TemperatureSDR,
 	    .sensorName = "Fan RPM\0",
@@ -137,6 +145,8 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .sampleCount = 0x1,
 	    .monitorFunc = &Temperature_Read_ACAP_Device_Sysmon,
 	},
+
+#ifndef PLATFORM_CS2200
 	{
 	    .repoType = TemperatureSDR,
 	    .sensorName = "QSFP0 Temp\0",
@@ -167,6 +177,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 		.sensorInstance = 2,
 	    .monitorFunc = &Temperature_Read_QSFP,
 	},
+#endif
     };
 
     /* Get Record Count */
@@ -912,7 +923,7 @@ s8 Monitor_Sensors(void)
     }
     else
     {
-	VMC_ERR("ASDM not yet Initialized \n\r");
+    	VMC_ERR("ASDM not yet Initialized \n\r");
     }
 }
 

--- a/src/vmc/vmc_demo.c
+++ b/src/vmc/vmc_demo.c
@@ -11,6 +11,7 @@
 #include "task.h"
 
 #include "cl_uart_rtos.h"
+#include "cl_config.h"
 
 /* VMC Header files */
 #include "vmc_api.h"
@@ -73,11 +74,18 @@ TestMenu TestsMenu[] =
     {"Get Board Info", NULL, BoardInfoTest},
     {"Sensor Data Read", NULL, SensorData_Display},
 
+#ifdef PLATFORM_CS2200
+
+    {"Temp LM75 Read", NULL, Temp_LM75_Display},
+    {"INA3221 Read", NULL, INA3221_Display},
+    {"ISL68220 Read", NULL, ISL68220_Display},
+
+#endif
+
     {NULL, NULL, NULL}
 };
 
 static bool isDemoMenuEnabled = false;
-extern SemaphoreHandle_t logbuf_lock; /* used to block until LogBuf is in use */
 
 static void App_SetLogLevel(void)
 {
@@ -266,14 +274,6 @@ int32_t Enable_DemoMenu(void)
     {
         return 0;
     }
-
-
-	/* logbuf is making log messages thread safe.*/
-	logbuf_lock = xSemaphoreCreateMutex();
-	if(logbuf_lock == NULL){
-		xil_printf("\n\r logbuf_lock creation failed \n\r");
-		return XST_FAILURE;
-	}
 
 
     if ( (retc = xTaskCreate(DemoMenuTask, "DemoMenu_Task", MENU_THREADSTACKSIZE, NULL, demoMenu_task_PRIORITY, NULL)) != pdPASS)

--- a/src/vmc/vmc_sc_comms.c
+++ b/src/vmc/vmc_sc_comms.c
@@ -4,7 +4,9 @@
 
 
 #include "vmc_sc_comms.h"
+#include "vmc_api.h"
 
+#ifndef PLATFORM_CS2200
 
 SC_VMC_Data sc_vmc_data;
 
@@ -186,7 +188,7 @@ bool Parse_SCData(u8 *Payload)
 			VMC_LOG("received error message  \r\n");
 			break;
 		default :
-			VMC_LOG("Unknown messageID : 0x%x\r\n",Payload[Rsp_MessageID])
+			VMC_LOG("Unknown messageID : 0x%x\r\n",Payload[Rsp_MessageID]);
 			break;
 		}
 	}
@@ -418,3 +420,5 @@ void vmc_sc_monitor()
 	}
 
 }
+
+#endif

--- a/src/vmc/vmc_sc_comms.h
+++ b/src/vmc/vmc_sc_comms.h
@@ -9,8 +9,9 @@
 
 #include "sysmon.h"
 #include "cl_uart_rtos.h"
-#include "vmc_api.h"
+#include "cl_config.h"
 
+#ifndef PLATFORM_CS2200
 
 extern uart_rtos_handle_t uart_vmcsc_log;
 
@@ -204,3 +205,5 @@ void vmc_Update_Sensors(u16 length,u8 *payload);
 void Update_SNSR_Data(u8 PayloadLength , u8 * payload);
 bool Parse_SCData(u8 *Payload);
 bool Vmc_Send_Packet(u8 Message_id , u8 Flags,u8 Payloadlength, u8 *Payload);
+
+#endif

--- a/src/vmc/vmc_sensors.h
+++ b/src/vmc/vmc_sensors.h
@@ -27,3 +27,4 @@ typedef struct
 void se98a_monitor(void);
 void max6639_monitor(void);
 void qsfp_monitor(void);
+void lm75_monitor(void);


### PR DESCRIPTION
- Define PLATFORM_CS2200 for adding CS2200 related code and disabling VCK5K code.
- PLATFORM_CS2200 is defined in cl_main.h.
- For enalbing CS2200, it's related XSA/PDI files must be used to build the BSP and program the board.
- Fixed a few bugs from PR(#41).

Signed-off-by: Shahab Alilou <shahaba@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
