### PR TITLE
CR-1120518 VCK5000 Discovery Upgrade fails when previous upgrade inte…

### DIFF
--- a/src/rmgmt/rmgmt_fpt.c
+++ b/src/rmgmt/rmgmt_fpt.c
@@ -54,6 +54,23 @@ static u32 rmgmt_fpt_pdi_get_base(struct cl_msg *msg, int fpt_type)
 	return 0;
 }
 
+static int rmgmt_fpt_pdi_meta_erase(struct cl_msg *msg, int fpt_type)
+{
+	u32 base_addr = rmgmt_fpt_pdi_get_base(msg, fpt_type);
+	int ret = 0;
+
+	if (base_addr == 0) {
+		RMGMT_ERR("base addr of fpt_type %d cannot be 0", fpt_type);
+		return -1;
+	}
+
+	RMGMT_LOG("reseting %d metdata", fpt_type); 
+
+	ret = ospi_flash_erase(CL_FLASH_BOOT, base_addr, OSPI_VERSAL_PAGESIZE);
+
+	return ret;
+}
+
 static int rmgmt_fpt_pdi_meta_get(struct cl_msg *msg, int fpt_type,
 	struct fpt_pdi_meta *meta)
 {
@@ -65,6 +82,8 @@ static int rmgmt_fpt_pdi_meta_get(struct cl_msg *msg, int fpt_type,
 		RMGMT_ERR("base addr of fpt_type %d cannot be 0", fpt_type);
 		return -1;
 	}
+
+	RMGMT_LOG("fpt_type %d", fpt_type);
 
 	ret = ospi_flash_read(CL_FLASH_BOOT, (u8 *)buf, base_addr, sizeof(buf));
 	if (ret)
@@ -85,6 +104,8 @@ static int rmgmt_fpt_pdi_meta_set(struct cl_msg *msg, int fpt_type,
 		RMGMT_ERR("base addr of fpt_type %d cannot be 0", fpt_type);
 		return -1;
 	}
+
+	RMGMT_LOG("fpt_type %d", fpt_type);
 
 	memcpy(buf, meta, sizeof(*meta));
 
@@ -423,8 +444,17 @@ int rmgmt_flush_rpu_pdi(struct rmgmt_handler *rh, struct cl_msg *msg)
 		return ret;
 
 	if (meta.fpt_pdi_magic != FPT_PDIMETA_MAGIC) {
-		RMGMT_ERR("invalid magic: %x", meta.fpt_pdi_magic);
-		return -1;
+		RMGMT_ERR("Invalid PDIMETA magic: %x", meta.fpt_pdi_magic);
+
+		if (!rmgmt_flush_no_backup(msg)) {
+			RMGMT_ERR("ERROR: not an enforced operation, rejected.");
+			return -1;
+		} else {
+			RMGMT_ERR("WARN: enforce to flash pdi onto default partition");
+
+			/* reset to valide magic number */
+			meta.fpt_pdi_magic = FPT_PDIMETA_MAGIC;
+		}
 	}
 
 	/* TODO: check not same checksum, avoid dup flush */
@@ -450,7 +480,13 @@ int rmgmt_flush_rpu_pdi(struct rmgmt_handler *rh, struct cl_msg *msg)
 
 	/* finaly step, update metadata */
 	meta.fpt_pdi_size = len;
+	ret = rmgmt_fpt_pdi_meta_erase(msg, FPT_TYPE_PDIMETA);
+	if (ret)
+		return ret;
+
 	ret = rmgmt_fpt_pdi_meta_set(msg, FPT_TYPE_PDIMETA, &meta);
+	if (ret)
+		return ret;
 
 	return ret;
 }


### PR DESCRIPTION
…rrupted

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

An interrupted flash pdi operation may leave the data on flash corrupted in any status, including all FFFF.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
We can enforce to flash the PDI by resetting the flash (erase then write) with correct metadata.
It is always the case that we have to erase then write, I am not sure if the ospi driver in ssw will improve this behavior. I will file a separate CR to address this. For now, we always erase first then write.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
