### PR TITLE
enable system dtb from ext fpt table

### DIFF
--- a/src/rmgmt/rmgmt_fpt.c
+++ b/src/rmgmt/rmgmt_fpt.c
@@ -158,6 +158,20 @@ int rmgmt_fpt_get_xsabin(struct cl_msg *msg, u32 *offset, u32 *size)
 	return 0;
 }
 
+int rmgmt_fpt_get_systemdtb(struct cl_msg *msg, u32 *offset, u32 *size)
+{
+	rmgmt_extension_fpt_query(msg);
+
+	if (!msg->multiboot_payload.has_ext_sysdtb) {
+		RMGMT_ERR("no system.dtb metadata");
+		return -1;
+	}
+
+	*offset = msg->multiboot_payload.sysdtb_offset;
+	*size = msg->multiboot_payload.sysdtb_size;
+	return 0;
+}
+
 /*
  * Read fpt table and return status
  */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
enable coping the system.dtb from pre-loaded DDR into pre-assigned location which is 0x40000 now.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
