### PR TITLE
CR-1120746 VCK5000 Discovery Boot failing with "xgq_submitted_cmd_che…

### DIFF
--- a/src/lscript.ld
+++ b/src/lscript.ld
@@ -28,7 +28,7 @@ MEMORY
    blp_shell_utils_remap_0_mem2 : ORIGIN = 0x20108000000, LENGTH = 0x8000000
    ulp_plram_ctrl_Mem0 : ORIGIN = 0x20204000000, LENGTH = 0x20000
    blp_shell_utils_remap_1_mem0 : ORIGIN = 0x20206000000, LENGTH = 0x1000000
-   blp_axi_noc_mc_C0_DDR_LOW0x4 : ORIGIN = 0x40000000, LENGTH = 0x40000000
+   blp_axi_noc_mc_C0_DDR_LOW0x4 : ORIGIN = 0x40000000, LENGTH = 0x30000000
    blp_axi_noc_mc_C0_DDR_LOW2x4 : ORIGIN = 0xC080000000, LENGTH = 0x380000000
    blp_cips_pspmc_0_psv_pmc_ram_psv_pmc_ram : ORIGIN = 0xF2000000, LENGTH = 0x20000
    blp_cips_pspmc_0_psv_r5_0_instruction_cache_psv_r5_0_instruction_cache : ORIGIN = 0xFFE40000, LENGTH = 0x10000


### PR DESCRIPTION
…ck: cmd id: 3 op: 0x8 timed out, hot reset is required!"

CR-1121149 ASTeR TC 7.01 - vck5000 - xclbin program fails during validate, error message: krnl_verify.setArg(0, d_buf), error code is: -48

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Verified it works for now. with latest 0207shell.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
