### PR TITLE
2022.1 vitis support - CR-1121036 2022.1 vitis VCK5000: xgq_submitted_cmd_check: cmd id: 0 op: 0xc timed out, hot reset is required! - Base 2

### DIFF
--- a/build/platform_2022.1_vitis.json
+++ b/build/platform_2022.1_vitis.json
@@ -1,0 +1,5 @@
+{
+  "CONFIG_FORCE_RESET" : "no",
+  "CONFIG_2022_1_VITIS" : "yes",
+}
+

--- a/build/platform_example.json
+++ b/build/platform_example.json
@@ -1,6 +1,0 @@
-{
-  "CONFIG_FORCE_RESET" : "yes",
-  "CONFIG_EXAMPLE1" : "no",
-  "CONFIG_EXAMPLE2" : "yes",
-}
-

--- a/src/include/vmr_common.h
+++ b/src/include/vmr_common.h
@@ -72,8 +72,14 @@
 
 #define APU_SHARED_MEMORY_START (0x37000000)
 #define APU_SHARED_MEMORY_END 	(0x37FF0000)
-#define APU_SQ_BASE (XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR + XGQ_SQ_TAIL_POINTER)
-#define APU_CQ_BASE (XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR + XGQ_CQ_TAIL_POINTER)
+
+/* tempory set this until TA xsa is changed to correct one */
+#ifndef XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR
+#define XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR
+#endif
+
+#define APU_SQ_BASE (XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR + XGQ_SQ_TAIL_POINTER)
+#define APU_CQ_BASE (XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR + XGQ_CQ_TAIL_POINTER)
 
 /* Reserve 4K for partition table */
 #define VMR_PARTITION_TABLE_SIZE	0x1000
@@ -106,3 +112,40 @@ static inline int rmgmt_enable_pl_reset() { return -ENODEV; }
 int32_t VMC_SCFW_Program_Progress(void);
 #endif
 
+
+int fpga_pdi_download(UINTPTR data, UINTPTR size, int has_pl);
+int fpga_pdi_download_workaround(UINTPTR data, UINTPTR size, int has_pl);
+#if defined(CONFIG_2022_1_VITIS)
+#ifdef STDIN_BASEADDRESS
+#undef STDIN_BASEADDRESS
+#endif
+#define STDIN_BASEADDRESS 0xFF010000
+
+#undef STDOUT_BASEADDRESS
+#define STDOUT_BASEADDRESS 0xFF01000
+
+#undef XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR
+#define XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR 0x80011000
+
+#undef XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR
+#define XPAR_BLP_BLP_LOGIC_XGQ_A2R_HIGHADDR 0x80011FFF
+
+#undef XPAR_BLP_BLP_LOGIC_XGQ_M2R_BASEADDR
+#define XPAR_BLP_BLP_LOGIC_XGQ_M2R_BASEADDR 0x80010000
+
+#undef XPAR_BLP_BLP_LOGIC_XGQ_M2R_HIGHADDR
+#define XPAR_BLP_BLP_LOGIC_XGQ_M2R_HIGHADDR 0x80010FFF
+
+static inline int pdi_download(UINTPTR data, UINTPTR size, int has_pl)
+{
+	//still has issues with 2022.1, :-(
+	//return fpga_pdi_download(data, size, has_pl);
+	return fpga_pdi_download_workaround(data, size, has_pl);
+}
+#else
+static inline int pdi_download(UINTPTR data, UINTPTR size, int has_pl)
+{
+	/* 2021.2 vitis has bugs, apply workaround */
+	return fpga_pdi_download_workaround(data, size, has_pl);
+}
+#endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enable vitis 2022.1 build by:
 ./build.sh  -platform platform_2022.1_vitis.json

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
