### PR TITLE
VMC: Added timeout to VMC -> SC FW update

### DIFF
--- a/src/vmc/vmc_main.c
+++ b/src/vmc/vmc_main.c
@@ -93,7 +93,7 @@ static void pVMCTask(void *params)
 	return ;
     }
 
-    /* Create the SC update task */
+    /* Create SC update task */
     SC_Update_Task_Create();
 
     vTaskSuspend(NULL);

--- a/src/vmc/vmc_sc_comms.c
+++ b/src/vmc/vmc_sc_comms.c
@@ -2,11 +2,10 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-
 #include "vmc_sc_comms.h"
+#include "vmc_update_sc.h"
 
 extern TaskHandle_t xVMCSCTask;
-extern TaskHandle_t xVMCUartpoll;
 
 SC_VMC_Data sc_vmc_data;
 
@@ -29,7 +28,7 @@ extern uint8_t sc_update_flag;
 u8 VMC_SC_Comms_Msg[] = {
        MSP432_COMMS_VOLT_SNSR_REQ,
        MSP432_COMMS_POWER_SNSR_REQ,
-	MSP432_COMMS_TEMP_SNSR_REQ,
+	   MSP432_COMMS_TEMP_SNSR_REQ,
        MSP432_COMMS_VMC_SEND_I2C_SNSR_REQ,
 };
 
@@ -469,8 +468,8 @@ void VMC_SC_CommsTask(void *params)
     	}
     	else
     	{
-    		/* Wait for SC update complete */
-    		vTaskDelay(2000);
+    		/* Wait for SC update complete ~20Sec*/
+    		vTaskDelay(DELAY_MS(1000 * 20));
     	}
     }
 

--- a/src/vmc/vmc_sensors.c
+++ b/src/vmc/vmc_sensors.c
@@ -587,8 +587,8 @@ void SensorMonitorTask(void *params)
     	}
     	else
     	{
-    		/* Wait for SC update complete */
-    		vTaskDelay(2000);
+    		/* Wait for SC update complete ~20Sec*/
+    		vTaskDelay(DELAY_MS(1000 * 20));
     	}
 
     }

--- a/src/vmc/vmc_update_sc.h
+++ b/src/vmc/vmc_update_sc.h
@@ -1,3 +1,7 @@
+/******************************************************************************
+ * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *******************************************************************************/
 
 #ifndef SRC_VMC_VMC_UPDATE_SC_H_
 #define SRC_VMC_VMC_UPDATE_SC_H_
@@ -9,7 +13,10 @@
 
 #define ULONG_MAX 						0xFFFFFFFFUL
 
-#define TIMEOUT_MS(x)   				( ((x)*10)     /portTICK_PERIOD_MS )
+#define DELAY_MS(x)   					((x)     /portTICK_PERIOD_MS )
+#define RCV_TIMEOUT_MS(x)  				((x)     /portTICK_PERIOD_MS )
+
+#define SC_UPDATE_MAX_RETRY_COUNT		(10u)
 
 #define BSL_VERSION_REQ					(0x06)
 #define BSL_VERSION_RESP				(0x11)
@@ -28,7 +35,11 @@
 #define BSL_DATA_WRITE_RESP_SEC_CHAR	(0x00)
 #define BSL_CRC_SUCCESS_RESP			(0x3A)
 #define BSL_SYNC_SUCCESS				(0x00)
+#define SC_BSL_SYNCED_REQ				(0x01)
+#define SC_BSL_SYNCED_RESP				(0x02)
 
+#define SC_ENABLE_BSL_REQ				(0x09)
+#define SC_ENABLE_BSL_RESP				(0x0A)
 
 #define CMD_RX_DATA_BLOCK_32			(0x20)
 #define CMD_RX_PASSWORD					(0x21)
@@ -87,7 +98,7 @@ typedef enum
 	STATUS_SUCCESS = 0,
 	STATUS_FAILURE,
 	STATUS_IN_PROGRESS
-}upgrade_status;
+}upgrade_status_t;
 
 typedef enum
 {
@@ -102,9 +113,27 @@ typedef enum
 	BSL_LOAD_PC_32,
 	MSP_GET_STATUS,
 	BSL_REBOOT_RESET,
-	TX_BSL_VERSION
-}upgrade_state;
+	TX_BSL_VERSION,
+	SC_BSL_SYNC
+}upgrade_state_t;
 
+
+typedef enum scUpateError_e
+{
+	SC_UPDATE_NO_ERROR = 0xE0,
+	SC_UP_TO_DATE_NO_UPDATE_REQ,
+	SC_UPDATE_ERROR_SC_BSL_SYNC_FAILED,
+	SC_UPDATE_ERROR_EN_BSL_FAILED,
+	SC_UPDATE_ERROR_VMC_BSL_SYNC_FAILED,
+	SC_UPDATE_ERROR_BSL_UNLOCK_PASSWORD_FAILED,
+	SC_UPDATE_ERROR_ERASE_FAILED,
+	SC_UPDATE_ERROR_INVALID_SC_SYMBOL_FOUND,
+	SC_UPDATE_ERROR_POST_CRC_FAILED,
+	SC_UPDATE_ERROR_INVALID_BSL_RESP,
+	SC_UPDATE_ERROR_NO_VALID_FPT_SC_FOUND,
+	SC_UPDATE_ERROR_FAILED_TO_GET_BSL_VERSION,
+	SC_UPDATE_ERROR_OPEARTION_TIMEDOUT
+}scUpateError_t;
 
 
 int32_t VMC_Start_SC_Update(void);
@@ -114,6 +143,6 @@ void VMC_Parse_Fpt_SC_Version(u32 addr_location, u8 *bsl_send_data_pkt);
 bool VMC_Read_SC_FW(void);
 u8 Get_SC_Checksum(void);
 u8 Check_Received_SC_Header(void *ptr1, void *ptr2, u8 len);
-upgrade_status matchCRC_postWrite(unsigned int writeAdd);
+upgrade_status_t matchCRC_postWrite(unsigned int writeAdd);
 
 #endif /* SRC_VMC_VMC_UPDATE_SC_H_ */


### PR DESCRIPTION
	- Added check to know whether MSP in BSL mode or SC mode.
	- Added 60Sec timeout to update process.
	- Valid error return codes added.
	- Stability fixes.

Signed-off-by: Sandeep Kumar Thakur <thakur@xilinx.com>
Signed-off-by: Sibasish Rout <sibasish@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
