### PR TITLE
ASDM: Do not send float values to XRT

### DIFF
--- a/src/vmc/vmc_asdm.c
+++ b/src/vmc/vmc_asdm.c
@@ -293,7 +293,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	{
 	    .repoType = TemperatureSDR,
 	    .sensorName = "Board Temp\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
+	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
 	    .sampleCount = 0x1,
@@ -303,7 +303,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	{
 	    .repoType = TemperatureSDR,
 	    .sensorName = "Sysmon Temp\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
+	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
 	    .sampleCount = 0x1,
@@ -323,7 +323,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	{
 	    .repoType = TemperatureSDR,
 	    .getSensorName = &getQSFPName,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
+	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
 	    .sampleCount = 0x1,
@@ -362,7 +362,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	{
 	    .repoType = PowerSDR,
 	    .sensorName = "Total Power\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
+	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
 	    .snsrUnitModifier = 0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
 	    .sampleCount = 0x1,

--- a/src/vmc/vmc_sensors.c
+++ b/src/vmc/vmc_sensors.c
@@ -135,8 +135,9 @@ s8 Temperature_Read_Board(snsrRead_t *snsrData)
 	status = max6639_ReadDDRTemperature(i2c_num, SLAVE_ADDRESS_MAX6639, &TempReading);
 	if (status == XST_SUCCESS)
 	{
-		memcpy(&snsrData->snsrValue[0],&TempReading,sizeof(TempReading));
-		snsrData->sensorValueSize = sizeof(TempReading);
+		u16 roundedOffVal = (TempReading > 0) ? TempReading : 0;
+		memcpy(&snsrData->snsrValue[0],&roundedOffVal,sizeof(roundedOffVal));
+		snsrData->sensorValueSize = sizeof(roundedOffVal);
 		snsrData->snsrSatus = Vmc_Snsr_State_Normal;
 	}
 	else
@@ -158,8 +159,9 @@ s8 Temperature_Read_ACAP_Device_Sysmon(snsrRead_t *snsrData)
 	status = XSysMonPsv_ReadTempProcessed(&InstancePtr, SYSMONPSV_TEMP_MAX, &TempReading);
 	if (status == XST_SUCCESS)
 	{
-		memcpy(&snsrData->snsrValue[0],&TempReading,sizeof(TempReading));
-		snsrData->sensorValueSize = sizeof(TempReading);
+		u16 roundedOffVal = (TempReading > 0) ? TempReading : 0;
+		memcpy(&snsrData->snsrValue[0],&roundedOffVal,sizeof(roundedOffVal));
+		snsrData->sensorValueSize = sizeof(roundedOffVal);
 		snsrData->snsrSatus = Vmc_Snsr_State_Normal;
 	}
 	else
@@ -223,8 +225,9 @@ s8 Temperature_Read_QSFP(snsrRead_t *snsrData)
 	static bool is_qsfp_critical_threshold_reached = false;
 	status = QSFP_ReadTemperature(&TempReading, snsrData->sensorInstance);
 
-	memcpy(&snsrData->snsrValue[0],&TempReading,sizeof(TempReading));
-	snsrData->sensorValueSize = sizeof(TempReading);
+	u16 roundedOffVal = (TempReading > 0) ? TempReading : 0;
+	memcpy(&snsrData->snsrValue[0],&roundedOffVal,sizeof(roundedOffVal));
+	snsrData->sensorValueSize = sizeof(roundedOffVal);
 
 	if (status == XST_SUCCESS)
 	{
@@ -320,13 +323,13 @@ s8 Power_Monitor(snsrRead_t *snsrData)
 
     if(totalPower != 0)
     {
-        memcpy(&snsrData->snsrValue[0],&totalPower,sizeof(totalPower));
-        snsrData->sensorValueSize = sizeof(totalPower);
+	u16 roundedOffVal = (totalPower > 0) ? totalPower : 0;
+        memcpy(&snsrData->snsrValue[0],&roundedOffVal,sizeof(roundedOffVal));
+        snsrData->sensorValueSize = sizeof(roundedOffVal);
         snsrData->snsrSatus = Vmc_Snsr_State_Normal;
     }
     else
     {
-        memcpy(&snsrData->snsrValue[0],&totalPower,sizeof(totalPower));
         snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
     }
 


### PR DESCRIPTION
Restricting max sensor size to 2 Bytes as the
XRT Host driver cannot accomodate float values.

Signed-off-by: Sandeep Kumar Thakur <thakur@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
