### PR TITLE
Refrain from using global variable to track SC update status

### DIFF
--- a/src/vmc/vmc_sc_comms.c
+++ b/src/vmc/vmc_sc_comms.c
@@ -444,33 +444,27 @@ void VMC_SC_CommsTask(void *params)
     for(;;)
     {
     	/* Notify SC of VMC Presence */
-    	if(!sc_update_flag)
-    	{
-    		if(!isVMCActive)
-    		{
-    			VMC_Fetch_SC_SensorData(MSP432_COMMS_VMC_ACTIVE_REQ);
-    		}
-    		/* Fetch the SC Version and Power Config  */
-    		if(!isPowerModeActive)
-    		{
-    			VMC_Fetch_SC_SensorData(MSP432_COMMS_VMC_VERSION_POWERMODE_REQ);
-    		}
-    		/* Fetch the Volt & power Sensor length  */
-    		if( isVMCActive &&  (!getSensorRespLen))
-    		{
-    			VMC_Fetch_SC_SensorData(MSP432_COMMS_VMC_GET_RESP_SIZE_REQ);
-    		}
-    		/*
-    		 *  Fetching Sensor values from SC
-    		 */
-    		VMC_Mointor_SC_Sensors();
-    		vTaskDelay(100);
-    	}
-    	else
-    	{
-    		/* Wait for SC update complete ~20Sec*/
-    		vTaskDelay(DELAY_MS(1000 * 20));
-    	}
+
+		if(!isVMCActive)
+		{
+			VMC_Fetch_SC_SensorData(MSP432_COMMS_VMC_ACTIVE_REQ);
+		}
+		/* Fetch the SC Version and Power Config  */
+		if(!isPowerModeActive)
+		{
+			VMC_Fetch_SC_SensorData(MSP432_COMMS_VMC_VERSION_POWERMODE_REQ);
+		}
+		/* Fetch the Volt & power Sensor length  */
+		if( isVMCActive &&  (!getSensorRespLen))
+		{
+			VMC_Fetch_SC_SensorData(MSP432_COMMS_VMC_GET_RESP_SIZE_REQ);
+		}
+		/*
+		 *  Fetching Sensor values from SC
+		 */
+		VMC_Mointor_SC_Sensors();
+		vTaskDelay(100);
+
     }
 
     vTaskSuspend(NULL);

--- a/src/vmc/vmc_sensors.c
+++ b/src/vmc/vmc_sensors.c
@@ -575,24 +575,16 @@ void SensorMonitorTask(void *params)
     for(;;)
     {
         /* Read All Sensors */
-    	if(!sc_update_flag)
-    	{
-    		Monitor_Sensors();
-    		Monitor_Thresholds();
+		Monitor_Sensors();
+		Monitor_Thresholds();
 
 #ifdef VMC_TEST
-    		se98a_monitor();
-    		max6639_monitor();
-    		sysmon_monitor();
-    		qsfp_monitor ();
+		se98a_monitor();
+		max6639_monitor();
+		sysmon_monitor();
+		qsfp_monitor ();
 #endif
-    		vTaskDelay(200);
-    	}
-    	else
-    	{
-    		/* Wait for SC update complete ~20Sec*/
-    		vTaskDelay(DELAY_MS(1000 * 20));
-    	}
+
 
     }
 


### PR DESCRIPTION
This patch replaces the global variable sc_update_flag with featuresof
FreeRTOS to stop and resume other tasks when SC firmware being updated.

Signed-off-by: Bhargava Sreekantappa Gayathri <bhargava.sreekantappa-gayathri@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
A global variable was used to check and pause threads when SC firmware update was going on.

#### How problem was solved, alternative solutions (if any) and why they were rejected
1) We were using a global variable before to track the status.

#### Risks (if any) associated the changes in the commit
2) If the firmware update thread gets stuck, then the sensor monitor and the comms thread won't be resumed.

#### What has been tested and how request additional testing if necessary
To be filled.
