### PR TITLE
enable reset xgq ring buffer thus we can replace vmr.elf without need…

### DIFF
--- a/src/common/cl_xgq_server.c
+++ b/src/common/cl_xgq_server.c
@@ -606,22 +606,14 @@ static void init_vmr_status(uint32_t ring_len)
 	IO_SYNC_WRITE32(0x0, RPU_SHARED_MEMORY_ADDR(mem.vmr_status_off));	
 }
 
-static inline void xgq_print_info()
-{
-#ifdef XGQ_SERVER
-	MSG_LOG("xgq server");
-#else
-	MSG_LOG("xgq client");
-#endif
-}
-
 static int init_xgq()
 {
 	int ret = 0;
 	size_t ring_len = RPU_RING_BUFFER_LEN;
 	uint64_t flags = 0;
 
-	xgq_print_info();
+	/* Reset ring buffer */
+	cl_memset_io8(RPU_RING_BUFFER_OFFSET, 0, ring_len);
 
         ret = xgq_alloc(&rpu_xgq, flags, xgq_io_hdl, RPU_RING_BUFFER_OFFSET, &ring_len,
 		RPU_XGQ_SLOT_SIZE, RPU_SQ_BASE, RPU_CQ_BASE);

--- a/src/include/cl_io.h
+++ b/src/include/cl_io.h
@@ -130,4 +130,16 @@ static inline int cl_memcpy(u32 dst_addr, u32 src_addr, size_t n)
 
 	return n;
 }
+
+static inline int cl_memset_io8(u32 dst, u8 val, size_t len)
+{
+	size_t i;
+
+	for (i = 0; i < len; i++, dst++ ) {
+		IO_SYNC_WRITE8(val, dst);
+	}
+
+	return len;
+}
+
 #endif


### PR DESCRIPTION
…ing a cold reboot

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

With max's recent enhancement in xgq_impl.h we can not reset xgq without resetting the whole RPU. We only need to stop any existing traffic in xgq (like rmmod xclmgmt), then clean up the xgq ring buffer, and re-init xgq.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
