### PR TITLE
Fix global variabe

### DIFF
--- a/src/vmc/vmc_main.c
+++ b/src/vmc/vmc_main.c
@@ -27,6 +27,8 @@ TaskHandle_t xVMCSCTask;
 TaskHandle_t xVMCTaskMonitor;
 
 SemaphoreHandle_t vmc_sc_lock;
+SemaphoreHandle_t vmc_sc_comms_lock;
+SemaphoreHandle_t vmc_sensor_monitoring_lock;
 
 int Enable_DemoMenu(void);
 
@@ -61,7 +63,13 @@ static void pVMCTask(void *params)
 
     /* Retry till fan controller is programmed */
     while (max6639_init(1, 0x2E));  // only for vck5000
-    
+
+	/* vmc_sensor_monitoring_lock */
+    vmc_sensor_monitoring_lock = xSemaphoreCreateMutex();
+	if(vmc_sensor_monitoring_lock == NULL){
+		VMC_ERR("vmc_sensor_monitoring_lock creation failed \n\r");
+	}
+
     /* Start Sensor Monitor task */
 
     if (xTaskCreate( SensorMonitorTask,
@@ -80,7 +88,12 @@ static void pVMCTask(void *params)
     if(vmc_sc_lock == NULL){
     VMC_ERR("vmc_sc_lock creation failed \n\r");
     }
-    xSemaphoreGive(vmc_sc_lock);
+
+	/* vmc_sc_comms_lock */
+    vmc_sc_comms_lock = xSemaphoreCreateMutex();
+	if(vmc_sc_comms_lock == NULL){
+		VMC_ERR("vmc_sc_comms_lock creation failed \n\r");
+	}
 
     if (xTaskCreate( VMC_SC_CommsTask,
 		( const char * ) "VMC_SC_Comms",

--- a/src/vmc/vmc_sc_comms.c
+++ b/src/vmc/vmc_sc_comms.c
@@ -10,7 +10,7 @@ extern TaskHandle_t xVMCSCTask;
 SC_VMC_Data sc_vmc_data;
 
 extern SemaphoreHandle_t vmc_sc_lock;
-
+extern SemaphoreHandle_t vmc_sc_comms_lock;
 /* VMC SC Comms handles and flags */
 extern uart_rtos_handle_t uart_vmcsc_log;
 
@@ -444,7 +444,7 @@ void VMC_SC_CommsTask(void *params)
     for(;;)
     {
     	/* Notify SC of VMC Presence */
-    	if(!sc_update_flag)
+    	if(xSemaphoreTake(vmc_sc_comms_lock, portMAX_DELAY) == pdTRUE)
     	{
     		if(!isVMCActive)
     		{
@@ -464,12 +464,8 @@ void VMC_SC_CommsTask(void *params)
     		 *  Fetching Sensor values from SC
     		 */
     		VMC_Mointor_SC_Sensors();
+    		xSemaphoreGive(vmc_sc_comms_lock);
     		vTaskDelay(100);
-    	}
-    	else
-    	{
-    		/* Wait for SC update complete ~20Sec*/
-    		vTaskDelay(DELAY_MS(1000 * 20));
     	}
     }
 


### PR DESCRIPTION
This patch replaces the global variable sc_update_flag with features of
FreeRTOS to stop and resume other tasks when SC firmware is updated.



Problem solved by the commit
A global variable was used to check and pause threads when SC firmware update was going on.

How problem was solved, alternative solutions (if any) and why they were rejected
We were using a global variable before to track the status.
Risks (if any) associated the changes in the commit
If the firmware update thread gets stuck, then the sensor monitor and the comms thread won't be resumed.
What has been tested and how request additional testing if necessary
To be filled.