### PR TITLE
CR-1124025 Clone of issue with summary: Remove flush_default_only res…

### DIFF
--- a/src/common/cl_xgq_server.c
+++ b/src/common/cl_xgq_server.c
@@ -135,7 +135,7 @@ int cl_msg_handle_complete(cl_msg_t *msg)
 		cmd_cq->cq_vmr_payload.ps_is_ready = cl_xgq_apu_is_ready();
 		cmd_cq->cq_vmr_payload.pl_is_ready = cl_xgq_pl_is_ready();
 
-		/* pass back log level and flush progress */
+		/* pass back log level and flash progress */
 		cmd_cq->cq_vmr_payload.debug_level = cl_loglevel_get();
 		cmd_cq->cq_vmr_payload.program_progress = flash_progress();
 	} else if (msg->hdr.type == CL_MSG_LOG_PAGE) {
@@ -348,14 +348,14 @@ static int submit_to_queue(u32 sq_addr)
 		msg.data_payload.address = (u32)sq->pdi_payload.address;
 		msg.data_payload.size = (u32)sq->pdi_payload.size;
 
-		switch (sq->pdi_payload.flush_type) {
-		case XGQ_CMD_FLUSH_NO_BACKUP:
-			msg.data_payload.flush_no_backup = 1;
+		switch (sq->pdi_payload.flash_type) {
+		case XGQ_CMD_FLASH_NO_BACKUP:
+			msg.data_payload.flash_no_backup = 1;
 			break;
-		case XGQ_CMD_FLUSH_TO_LEGACY:
-			msg.data_payload.flush_to_legacy = 1;
+		case XGQ_CMD_FLASH_TO_LEGACY:
+			msg.data_payload.flash_to_legacy = 1;
 			break;
-		case XGQ_CMD_FLUSH_DEFAULT:
+		case XGQ_CMD_FLASH_DEFAULT:
 		default:
 			break;
 		}

--- a/src/common/xgq_cmd_vmr.h
+++ b/src/common/xgq_cmd_vmr.h
@@ -172,15 +172,15 @@ struct xgq_cmd_data_payload {
 	uint32_t size;
 	uint32_t remain_size;
 	uint32_t addr_type:4;
-	uint32_t flush_type:4;
+	uint32_t flash_type:4;
 	uint32_t rsvd1:24;
 	uint32_t pad1;
 };
 
-enum xgq_cmd_flush_type {
-	XGQ_CMD_FLUSH_DEFAULT		= 0x0,
-	XGQ_CMD_FLUSH_NO_BACKUP		= 0x1,
-	XGQ_CMD_FLUSH_TO_LEGACY		= 0x2,
+enum xgq_cmd_flash_type {
+	XGQ_CMD_FLASH_DEFAULT		= 0x0,
+	XGQ_CMD_FLASH_NO_BACKUP		= 0x1,
+	XGQ_CMD_FLASH_TO_LEGACY		= 0x2,
 };
 
 /**

--- a/src/include/cl_msg.h
+++ b/src/include/cl_msg.h
@@ -54,8 +54,8 @@ struct xgq_vmr_data_payload {
 	uint32_t address;
 	uint32_t size;
 	uint32_t addr_type:4;
-	uint32_t flush_no_backup:1;
-	uint32_t flush_to_legacy:1;
+	uint32_t flash_no_backup:1;
+	uint32_t flash_to_legacy:1;
 	uint32_t rsvd1:26;
 	uint32_t pad1;
 };

--- a/src/rmgmt/rmgmt_fpt.h
+++ b/src/rmgmt/rmgmt_fpt.h
@@ -60,7 +60,7 @@ void rmgmt_fpt_query(struct cl_msg *msg);
 void rmgmt_boot_fpt_query(struct cl_msg *msg);
 void rmgmt_extension_fpt_query(struct cl_msg *msg);
 
-int rmgmt_flush_rpu_pdi(struct rmgmt_handler *rh, struct cl_msg *msg);
+int rmgmt_flash_rpu_pdi(struct rmgmt_handler *rh, struct cl_msg *msg);
 
 int rmgmt_fpt_get_xsabin(struct cl_msg *msg, u32 *addr, u32 *size);
 int rmgmt_fpt_get_scfw(struct cl_msg *msg, u32 *addr, u32 *size);

--- a/src/rmgmt/rmgmt_main.c
+++ b/src/rmgmt/rmgmt_main.c
@@ -104,7 +104,7 @@ static int rmgmt_download_pdi(cl_msg_t *msg, bool is_rpu_pdi)
 	cl_memcpy_fromio8(address, rh.rh_data, size);
 
 	if (is_rpu_pdi)
-		ret = rmgmt_flush_rpu_pdi(&rh, msg);
+		ret = rmgmt_flash_rpu_pdi(&rh, msg);
 	else
 		ret = rmgmt_download_apu_pdi(&rh);
 


### PR DESCRIPTION
…triction when upgrading from backup

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

this is for fixing the typo from flush to flash. people gets confused about the name in sysfs and XGQ interfaces

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
