### PR TITLE
CR-1123097 ASTeR basic sanity - vck5000 - VMR version not displayed

### DIFF
--- a/src/common/cl_main.c
+++ b/src/common/cl_main.c
@@ -69,11 +69,11 @@ u32 cl_rpu_status_query(struct cl_msg *msg, char *buf, u32 size)
 	u32 count = 0;
 
 #ifdef VMR_BUILD_XRT_ONLY
-	CL_LOG(APP_MAIN, "XRT only build");
-	count = snprintf(buf, size, "XRT only build\n");	
+	CL_LOG(APP_MAIN, "Build flags: -XRT");
+	count = snprintf(buf, size, "Build flags: -XRT\n");
 #else
-	CL_LOG(APP_MAIN, "VMR full build");
-	count = snprintf(buf, size, "VMR full build\n");	
+	CL_LOG(APP_MAIN, "Build flags: default full build");
+	count = snprintf(buf, size, "Build flags: default full build\n");
 #endif
 
 	if (count > size) {
@@ -86,10 +86,10 @@ u32 cl_rpu_status_query(struct cl_msg *msg, char *buf, u32 size)
 	CL_LOG(APP_MAIN, "vitis version: %s", VMR_TOOL_VERSION);
 	CL_LOG(APP_MAIN, "git hash: %s", VMR_GIT_HASH);
 	CL_LOG(APP_MAIN, "git branch: %s", VMR_GIT_BRANCH);
-	CL_LOG(APP_MAIN, "build date: %s", VMR_GIT_HASH_DATE);
+	CL_LOG(APP_MAIN, "git hash date: %s", VMR_GIT_HASH_DATE);
 
 	count += snprintf(buf + count, size,
-		"Vitis version: %s\ngit hash: %s\ngit branch: %s\nbuild date: %s\n",
+		"vitis version: %s\ngit hash: %s\ngit branch: %s\ngit hash date: %s\n",
 		VMR_TOOL_VERSION, VMR_GIT_HASH, VMR_GIT_BRANCH, VMR_GIT_HASH_DATE);
 	if (count > size) {
 		CL_ERR(APP_MAIN, "msg is truncated");
@@ -105,7 +105,7 @@ u32 cl_apu_status_query(struct cl_msg *msg, char *buf, u32 size)
 	u32 count = 0;
 
 	//cl_xgq_apu_identify(msg);
-	count = snprintf(buf, size, "apu is ready: %d\n", cl_xgq_apu_is_ready()); 
+	count = snprintf(buf, size, "is PS ready: %d\n", cl_xgq_apu_is_ready());
 
 	return count;
 }

--- a/src/rmgmt/rmgmt_main.c
+++ b/src/rmgmt/rmgmt_main.c
@@ -274,7 +274,8 @@ static u32 rmgmt_fpt_status_query(cl_msg_t *msg, char *buf, u32 size)
 
 	rmgmt_fpt_query(msg);
 
-	count = snprintf(buf, size, "A image offset: 0x%lx size: 0x%lx capacity: 0x%lx\n",
+	count = snprintf(buf, size, "default image offset: 0x%lx\n"
+		"default image size: 0x%lx\ndefault image capacity: 0x%lx\n",
 		msg->multiboot_payload.default_partition_offset,
 		msg->multiboot_payload.pdimeta_size,
 		msg->multiboot_payload.default_partition_size);
@@ -283,8 +284,8 @@ static u32 rmgmt_fpt_status_query(cl_msg_t *msg, char *buf, u32 size)
 		return size;
 	}
 	
-	count += snprintf(buf + count, size,
-		"B image offset: 0x%lx size: 0x%lx capacity: 0x%lx\n",
+	count += snprintf(buf + count, size, "backup image offset: 0x%lx\n"
+		"backup image size: 0x%lx\nbackup image capacity: 0x%lx\n",
 		msg->multiboot_payload.backup_partition_offset,
 		msg->multiboot_payload.pdimeta_backup_size,
 		msg->multiboot_payload.backup_partition_size);


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is to make sure XRT tools can decode the verbose info correctly. example:
```
cat /sys/bus/pci/devices/0000\:09\:00.0/xgq_vmr.m.54525952/vmr_verbose_info
Build flags: default full build
vitis version: 2021.2
git hash: e3193d8ce10357ca6e82473b0f87e9b4107f4111
git branch: 2022_p1
git hash date: Mon, 7 Mar 2022 10:46:44 -0800
is PS ready: 0
default image offset: 0x48000
default image size: 0x67bb50
default image capacity: 0x5fb8000
backup image offset: 0x6008000
backup image size: 0x6fec60
backup image capacity: 0x5fb8000
SC firmware size: 0x630f0
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
