### PR TITLE
adjust some xparameters for 2022.1 shell

### DIFF
--- a/src/include/vmr_common.h
+++ b/src/include/vmr_common.h
@@ -84,11 +84,6 @@
 #define APU_SHARED_MEMORY_START (0x37000000)
 #define APU_SHARED_MEMORY_END 	(0x37FF0000)
 
-/* tempory set this until TA xsa is changed to correct one */
-#ifndef XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR
-#define XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR
-#endif
-
 #define APU_SQ_BASE (XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR + XGQ_SQ_TAIL_POINTER)
 #define APU_CQ_BASE (XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR + XGQ_CQ_TAIL_POINTER)
 
@@ -127,18 +122,20 @@ int fpga_pdi_download(UINTPTR data, UINTPTR size, int has_pl);
 int fpga_pdi_download_workaround(UINTPTR data, UINTPTR size, int has_pl);
 
 #if defined(CONFIG_2022_1_VITIS)
-
+/*
+ * This is the workaround hardcode for 2022.1 xparameters.h only
+ */
 #undef STDIN_BASEADDRESS
 #define STDIN_BASEADDRESS 0xFF010000
 
 #undef STDOUT_BASEADDRESS
-#define STDOUT_BASEADDRESS 0xFF01000
+#define STDOUT_BASEADDRESS 0xFF010000
 
-#undef XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR
-#define XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR 0x80011000
+#undef XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR
+#define XPAR_BLP_BLP_LOGIC_XGQ_R2A_BASEADDR 0x80011000
 
-#undef XPAR_BLP_BLP_LOGIC_XGQ_A2R_BASEADDR
-#define XPAR_BLP_BLP_LOGIC_XGQ_A2R_HIGHADDR 0x80011FFF
+#undef XPAR_BLP_BLP_LOGIC_XGQ_R2A_HIGHADDR
+#define XPAR_BLP_BLP_LOGIC_XGQ_R2A_HIGHADDR 0x80011FFF
 
 #undef XPAR_BLP_BLP_LOGIC_XGQ_M2R_BASEADDR
 #define XPAR_BLP_BLP_LOGIC_XGQ_M2R_BASEADDR 0x80010000
@@ -153,10 +150,11 @@ static inline int pdi_download(UINTPTR data, UINTPTR size, int has_pl)
 }
 
 #else
-
+/*
+ * This is default api wrapper for default
+ */
 static inline int pdi_download(UINTPTR data, UINTPTR size, int has_pl)
 {
-	/* 2021.2 has patches now*/
 	return fpga_pdi_download(data, size, has_pl);
 	//return fpga_pdi_download_workaround(data, size, has_pl);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

fix the hardcoded endpoint for XGQ. seems working fine now for base2 shell.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
