### PR TITLE
CR-1121036 2022.1 vitis VCK5000: fix build.sh with daily_latest 

### DIFF
--- a/build/create_app.tcl
+++ b/build/create_app.tcl
@@ -1,4 +1,6 @@
 setws .
 puts "create app"
-app create -name vmr -platform vmr_platform -domain freertos10_xilinx_domain -template "Empty Application(C)"
-#app create -name vmr -platform vmr_platform -domain freertos10_xilinx_domain -template "Empty Application"
+set xsaName $::env(FORCE_MARK_XSA_NAME)
+puts "xsaName is: $xsaName"
+app create -name vmr -platform ${xsaName} -domain freertos10_xilinx_domain -template "Empty Application(C)"
+

--- a/build/create_bsp.tcl
+++ b/build/create_bsp.tcl
@@ -12,8 +12,9 @@ platform create -out vmr_platform -name {vmr_platform} -hw xsa/vmr.xsa -proc {bl
 
 if { [lindex $argv 1] == 1 } {
 	puts "=== use 2022.1 daily_lastest embeddedws"
+	# comment out ssw patches
 	#repo -set /proj/xsjhdstaff2/davidzha/ssw_2022.1/
-	repo -set /public/bugcases/CR/1105000-1105999/1105240/ssw_2022.1/
+	#repo -set /public/bugcases/CR/1105000-1105999/1105240/ssw_2022.1/
 } else {
 	puts "===  patching 2021.2 fixes for non-daily_latest stable builds"
 	#repo -set /proj/rdi/staff/davidzha/embeddedsw/

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -1,1 +1,2 @@
-export FORCE_MARK_AS_EDGE_XSA=1
+#export FORCE_MARK_AS_EDGE_XSA=1
+export FORCE_MARK_XSA_NAME=xilinx_vck5000_gen4x8_xdma_2_202210_1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is to enable 2022.1 base2 daily build.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
given the 2022.1 xsa is generated by 2022.1 vitis.
some 2021.2 xsa might not work with 2022.1 vitis.

So please use 2022.1 vitis if you source vitis before running build.sh.
By default, the build.sh will pick 2022.1 vitis.

example:
./build.sh -xsa /proj/rdi/staff/davidzha/share/xgq/0308.xsa -platform platform_2022.1_vitis.json -jtag

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
