### PR TITLE
Fix for CR-1123054 :

### DIFF
--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -38,6 +38,7 @@
 #define NUM_SC_VOLTAGE_SENSORS  (6)
 #define NUM_SC_CURRENT_SENSORS  (4)
 #define NUM_POWER_SENSORS       (1)
+#define CURRENT_SENSORS_INSTANCES (3)
 
 #define SNSRNAME_ACTIVE_SC_VER "Active SC Ver\0"
 
@@ -56,6 +57,7 @@ extern s8 Fan_RPM_Read(snsrRead_t *snsrData);
 extern s8 Temperature_Read_QSFP(snsrRead_t *snsrData);
 extern s8 PMBUS_SC_Sensor_Read(snsrRead_t *snsrData);
 extern s8 Power_Monitor(snsrRead_t *snsrData);
+extern s8 PMBUS_SC_Vccint_Read(snsrRead_t *snsrData);
 
 Asdm_Sensor_Thresholds_t thresholds_limit_tbl[]= {
     /*  Name           LW   LC   LF    UW   UC  UF  */
@@ -86,7 +88,6 @@ void getCurrentNames(u8 index, char8* snsrName, u8 *sensorId)
     };
 
     struct sensorData snsrData[] =    {
-        { VCCINT_I,       "VCCINT\0"   },
         { PEX_12V_I_IN,   "12V PEX\0"  },
         { V12_IN_AUX0_I,  "12V AUX0\0" },
         { V12_IN_AUX1_I,  "12V AUX1\0" },
@@ -345,8 +346,18 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .snsrUnitModifier = -3,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
 	    .sampleCount = 0x1,
-	    .sensorInstance = NUM_SC_CURRENT_SENSORS,
+	    .sensorInstance = CURRENT_SENSORS_INSTANCES,
 	    .monitorFunc = &PMBUS_SC_Sensor_Read,
+	},
+	{
+	    .repoType = CurrentSDR,
+	    .sensorName = "VCCINT\0",
+	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
+	    .snsrUnitModifier = -3,
+	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
+	    .sampleCount = 0x1,
+	    .sesnorListTbl = VCCINT_I,
+	    .monitorFunc = &PMBUS_SC_Vccint_Read,
 	},
 	{
 	    .repoType = PowerSDR,
@@ -1234,20 +1245,22 @@ void AsdmSensor_Display(void)
 		}
 		else if((sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK) < 4)
 		{
+
 			VMC_PRNT(" %s		%d		%s	%d	%d \n\r",(sensorRecord[idx].sensor_name),
-				*((u16 *)sensorRecord[idx].sensor_value),
-				((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal) ? "Ok":"Error"),
-				*((u16 *)(sensorRecord[idx].sensorMaxValue)),
-				*((u16 *)(sensorRecord[idx].sensorAverageValue)));
+					*((u16 *)sensorRecord[idx].sensor_value),
+					((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal) ? "Ok":"Error"),
+					*((u16 *)(sensorRecord[idx].sensorMaxValue)),
+					*((u16 *)(sensorRecord[idx].sensorAverageValue)));
+
 		}
-		else if((sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK) == sizeof(float))
+		else if((sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK) == sizeof(u32))
 		{
 
-			VMC_PRNT(" %s		%0.3f		%2s	%0.3f	%0.3f \n\r",(sensorRecord[idx].sensor_name),
-				*((float *)sensorRecord[idx].sensor_value),
+			VMC_PRNT(" %s		%d		%s	%d	%d \n\r",(sensorRecord[idx].sensor_name),
+				*((u32 *)sensorRecord[idx].sensor_value),
 				((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal) ? "Ok":"Error"),
-				*((float *)(sensorRecord[idx].sensorMaxValue)),
-				*((float *)(sensorRecord[idx].sensorAverageValue)));
+				*((u32 *)(sensorRecord[idx].sensorMaxValue)),
+				*((u32 *)(sensorRecord[idx].sensorAverageValue)));
 		}
 	    }
 	}

--- a/vmr/src/vmc/vmc_sc_comms.c
+++ b/vmr/src/vmc/vmc_sc_comms.c
@@ -58,7 +58,7 @@ u16 vmcU8ToU16(u8 *payload) {
 }
 uint32_t vmcU8ToU32(uint8_t* payload)
 {
-	return (uint32_t)payload[3] | (((uint32_t)payload[2]) << 8) | (((uint32_t)payload[1]) << 16) | (((uint32_t)payload[0]) << 24);
+	return (uint32_t)payload[0] | (((uint32_t)payload[1]) << 8) | (((uint32_t)payload[2]) << 16) | (((uint32_t)payload[3]) << 24);
 }
 uint64_t vmcU8ToU64(uint8_t * payload)
 {
@@ -114,9 +114,14 @@ void VMC_Update_Version_PowerMode(u16 length,u8 *payload)
 void VMC_StoreSensor_Value(u8 id, u32 value)
 {
 
+
 	if (xSemaphoreTake(vmc_sc_lock, portMAX_DELAY))
 	{
-		sc_vmc_data.sensor_values[id] = value;
+		if(id == VCCINT_I) {
+			sc_vmc_data.VCCINT_sensor_value = value;
+		} else {
+			sc_vmc_data.sensor_values[id] = value;
+		}
 		xSemaphoreGive(vmc_sc_lock);
 	}
 	else

--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -269,6 +269,7 @@ typedef struct SC_VMC_Data{
     u8   availpower;
     u8   configmode;
     u8   scVersion[4];
+    u32  VCCINT_sensor_value;
     u16  sensor_values[SENSOR_ID_MAX];
 }SC_VMC_Data;
 

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -263,33 +263,66 @@ s8 Temperature_Read_QSFP(snsrRead_t *snsrData)
 
 s8 PMBUS_SC_Sensor_Read(snsrRead_t *snsrData)
 {
-    s8 status = XST_FAILURE;
-    u16 sensorReading = 0;
+	s8 status = XST_FAILURE;
+	u16 sensorReading = 0;
 
-    if (xSemaphoreTake(vmc_sc_lock, portMAX_DELAY))
-    {
-    	sensorReading = sc_vmc_data.sensor_values[snsrData->mspSensorIndex];
-    	xSemaphoreGive(vmc_sc_lock);
-    }
-    else
-    {
-    	VMC_ERR("vmc_sc_lock lock failed \r\n");
-    }
+	if (xSemaphoreTake(vmc_sc_lock, portMAX_DELAY))
+	{
+		sensorReading = sc_vmc_data.sensor_values[snsrData->mspSensorIndex];
+		xSemaphoreGive(vmc_sc_lock);
+	}
+	else
+	{
+		VMC_ERR("vmc_sc_lock lock failed \r\n");
+	}
 
-    if(sensorReading != 0)
-    {
-        memcpy(&snsrData->snsrValue[0],&sensorReading,sizeof(sensorReading));
-        snsrData->sensorValueSize = sizeof(sensorReading);
-        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
-    }
-    else
-    {
-    	memcpy(&snsrData->snsrValue[0],&sensorReading,sizeof(sensorReading));
-        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
-        VMC_DBG("MSP Sensor Id : %d Data read failed \n\r",snsrData->mspSensorIndex);
-    }
+	if(sensorReading != 0)
+	{
+		memcpy(&snsrData->snsrValue[0],&sensorReading,sizeof(sensorReading));
+		snsrData->sensorValueSize = sizeof(sensorReading);
+		snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+	}
+	else
+	{
+		memcpy(&snsrData->snsrValue[0],&sensorReading,sizeof(sensorReading));
+		snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+		VMC_DBG("MSP Sensor Id : %d Data read failed \n\r",snsrData->mspSensorIndex);
+	}
 
-    return status;
+	return status;
+}
+
+s8 PMBUS_SC_Vccint_Read(snsrRead_t *snsrData)
+{
+	s8 status = XST_FAILURE;
+	u32 vccint_i_sensorReading = 0;
+
+
+	if (xSemaphoreTake(vmc_sc_lock, portMAX_DELAY))
+	{
+		vccint_i_sensorReading = sc_vmc_data.VCCINT_sensor_value;
+		xSemaphoreGive(vmc_sc_lock);
+	}
+	else
+	{
+		VMC_ERR("vmc_sc_lock lock failed \r\n");
+	}
+
+	if(vccint_i_sensorReading != 0)
+	{
+		memcpy(&snsrData->snsrValue[0],&vccint_i_sensorReading,sizeof(vccint_i_sensorReading));
+		snsrData->sensorValueSize = sizeof(vccint_i_sensorReading);
+		snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+	}
+	else
+	{
+		memcpy(&snsrData->snsrValue[0],&vccint_i_sensorReading,sizeof(vccint_i_sensorReading));
+		snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+		VMC_DBG("MSP Sensor Id : %d Data read failed \n\r",snsrData->mspSensorIndex);
+	}
+
+
+	return status;
 }
 
 s8 Power_Monitor(snsrRead_t *snsrData)


### PR DESCRIPTION
	- Fixed VCCint_current reading from SC

Signed-off-by : Himasagar Reddy <himasaga@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Vccint current value is  now displayed correctly 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

these has been tested in both Demo menu and through examine commands 

 xbutil examine -r electrical -d 0000:29:00.1

Electrical
  Max Power              : NA Watts
  Power                  : 36 Watts
  Power Warning          : NA

  Power Rails            : Voltage   Current
  12V PEX                : 12.025 V,  0.774 A
  3V3 PEX                :  3.287 V
  3V3 AUX                :  3.375 V
  12V AUX0               : 12.031 V,  2.033 A
  12V AUX1               : 12.030 V,  0.302 A
  VCCINT                 :  0.804 V, **66.400** A

#### Documentation impact (if any)
