### PR TITLE
path to resilient VMR - debug tasks

### DIFF
--- a/vmr/src/include/cl_main.h
+++ b/vmr/src/include/cl_main.h
@@ -32,14 +32,17 @@ struct cl_msg;
 u32 cl_rpu_status_query(struct cl_msg *msg, char *buf, u32 size);
 u32 cl_apu_status_query(struct cl_msg *msg, char *buf, u32 size);
 
-int cl_xgq_client_probe(void);
 int cl_xgq_apu_is_ready(void);
 int cl_xgq_pl_is_ready(void);
+int cl_rmgmt_is_ready(void);
+int cl_xgq_client_probe(void);
+
 int cl_xgq_apu_identify(struct cl_msg *msg);
 int cl_xgq_apu_download_xclbin(char *data, u32 size);
 
 #define TASK_STACK_DEPTH 0x10000 /* 64k * sizeof(word) = 256k */
 int flash_progress(void);
 int32_t VMC_SCFW_Program_Progress(void);
+void cl_start_vmc_tasks();
 
 #endif

--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -20,6 +20,7 @@
 
 static TaskHandle_t xXGQTask;
 static struct rmgmt_handler rh = { 0 };
+static bool rmgmt_is_ready = false;
 msg_handle_t *pdi_hdl;
 msg_handle_t *xclbin_hdl;
 msg_handle_t *af_hdl;
@@ -753,11 +754,20 @@ static void pvXGQTask( void *pvParameters )
 		if (xgq_apu_control_flag == 0 && xgq_apu_channel_probe() == 0) {
 			RMGMT_LOG("apu is ready.");
 			xgq_apu_control_flag = 1;
+			/* all rmgmt callbacks are ready, sensor cb can be inited later */
+			rmgmt_is_ready = true;
 		}
 
 		RMGMT_DBG("free heap %d", xPortGetFreeHeapSize());
 	}
+	/* should never been here */
 	RMGMT_LOG("done");
+}
+
+int cl_rmgmt_is_ready()
+{
+	RMGMT_DBG("%s", rmgmt_is_ready ? "READY" : "NOT READY");
+	return rmgmt_is_ready;
 }
 
 static int rmgmt_create_tasks(void)

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -37,6 +37,10 @@ u8 Enable_DemoMenu(void);
 extern void VMC_SC_CommsTask(void *params);
 extern void SensorMonitorTask(void *params);
 
+void cl_start_vmc_tasks() {
+	xTaskNotifyGive(xVMCTask); 
+}
+
 static void pVMCTask(void *params)
 {
     /* Platform Init will Initialise I2C, GPIO, SPI, etc */
@@ -44,7 +48,15 @@ static void pVMCTask(void *params)
     s8 Status;
     XGpio Gpio;
 
-    VMC_LOG(" VMC launched \n\r");
+    VMC_LOG(" VMC is starting... ");
+
+    /*
+     * Cold boot case: wait 2 mins for bios to finish booting.
+     * Hot reset case: if driver attached, driver notify and continue immediately.
+     */
+    ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000 * 60 * 2));
+
+    VMC_LOG(" VMC start launching \n\r");
 
     I2CInit();
 
@@ -112,6 +124,7 @@ static void pVMCTask(void *params)
 	return ;
     }
 
+    VMC_LOG("VMC Launch done");
 
     vTaskSuspend(NULL);
 }
@@ -128,7 +141,6 @@ int VMC_Launch( void )
 	CL_LOG(APP_VMC,"Failed to Create VMC Task \n\r");
 	return -1;
     }
-
     return 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Given the situation where on Dell EPIC amd server and intel server, the bios can take 2-3 minutes to boot successfully. It is very dangerous to start VMC tasks right after cold reboot.

However, we eventually should get VMC tasks started.
We also need to get VMC tasks started right away when XRT host driver attached.

So the solution is:
1) for cold reboot, wait for a safe period then start VMC tasks;
2) for warm reboot, hot reset, whenever driver attached notify the VMC task to start immediately.


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

In addition, I am working on another better way to re-organize all tasks to static (eventually controlled by MPU). But that change is too big for now. The main idea for the work is to create tasks with in a group and start the task by a carefully reviewed procedure rather than start all tasks as of today.

It is very dangerous to operate on hardware when the hardware is not ready. I saw too many hardware hung issues.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
