### PR TITLE
cached bsp needs to updated the heap size too

### DIFF
--- a/bsp/2021.2_stable/bsp/psv_cortexr5_0/libsrc/freertos10_xilinx_v1_10/src/FreeRTOSConfig.h
+++ b/bsp/2021.2_stable/bsp/psv_cortexr5_0/libsrc/freertos10_xilinx_v1_10/src/FreeRTOSConfig.h
@@ -78,7 +78,7 @@
 
 #define configMINIMAL_STACK_SIZE ( ( unsigned short ) 200)
 
-#define configTOTAL_HEAP_SIZE ( ( size_t ) ( 65536 * 4 * 50 ) )
+#define configTOTAL_HEAP_SIZE ( ( size_t ) ( 0x16000000 ) )
 
 #define configMAX_TASK_NAME_LEN 10
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Forget to update stable bsp, the code has been changed to use pvMalloc.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
