### PR TITLE
CR-1126707 msg->log_payload.size set incorrectly

### DIFF
--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -486,7 +486,7 @@ static u32 vmr_check_firewall(cl_msg_t *msg)
 		
 		RMGMT_ERR("tripped status: 0x%x", val);
 
-		if (msg->log_payload.size < sizeof(log_msg)) {
+		if (msg->log_payload.size < safe_size) {
 			RMGMT_ERR("log buffer %d is too small, log message %d is trunked",
 				msg->log_payload.size, sizeof(log_msg));
 			safe_size = msg->log_payload.size;
@@ -494,10 +494,13 @@ static u32 vmr_check_firewall(cl_msg_t *msg)
 
 		count = snprintf(log_msg, safe_size,
 			"AXI Firewall User is tripped, status: 0x%lx\n", val);
+		if (count > safe_size) 
+			RMGMT_WARN("log msg is trunked");
+
 		cl_memcpy_toio8(dst_addr, &log_msg, safe_size);
 
 		/* set correct size in result payload */
-		msg->log_payload.size = count;
+		msg->log_payload.size = safe_size;
 	}
 
 	return val;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

fix nits, but better to make the return size correct to safe_size so people won't get confuzed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
