### PR TITLE
CR-1126641 : Added Check to validate SC 

### DIFF
--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -285,3 +285,6 @@ void VMC_Update_Sensors(u16 length,u8 *payload);
 void Update_SNSR_Data(u8 PayloadLength , u8 * payload);
 bool Parse_SCData(u8 *Payload);
 bool VMC_send_packet(u8 Message_id , u8 Flags,u8 Payloadlength, u8 *Payload);
+bool vmc_get_sc_status();
+void vmc_set_sc_status(bool value);
+

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -619,18 +619,22 @@ done:
 
 void SensorMonitorTask(void *params)
 {
+
     VMC_LOG(" Sensor Monitor Task Created !!!\n\r");
 
     if(Init_Asdm())
     {
          VMC_ERR(" ASDM Init Failed \n\r");
     }
-    
+
     if (xgq_sensor_flag == 0 &&
         cl_msg_handle_init(&sensor_hdl, CL_MSG_SENSOR, xgq_sensor_cb, NULL) == 0) {
         VMC_LOG("init sensor handle done.");
         xgq_sensor_flag = 1;
     }
+
+	/* Wait for notification from VMC_SC_CommsTask */
+	xTaskNotifyWait(ULONG_MAX, ULONG_MAX, NULL, portMAX_DELAY);
 
     for(;;)
     {

--- a/vmr/src/vmc/vmc_update_sc.h
+++ b/vmr/src/vmc/vmc_update_sc.h
@@ -71,8 +71,8 @@
 
 #define BSL_MAX_DATA_SIZE				(266u)
 
-#define SC_HEADER_SIZE					(0x0000000B)
-#define SC_RES_HEADER_SIZE	    		(0x00000005)
+#define SC_HEADER_SIZE					(0x0B)
+#define SC_RES_HEADER_SIZE				(0x05)
 #define SC_TOT_HEADER_SIZE				(SC_HEADER_SIZE + SC_RES_HEADER_SIZE)
 #define SC_HEADER_MSG					("VERSAL_SCFW")
 


### PR DESCRIPTION
     - The sensor monitor task will wait until valid communication
	  established between SC <-> VMC
     -  Fixed the I2C-main race condition after an SC update
       
Signed-off-by: Himasagar Reddy <himasaga@xilinx.com>
Signed-off-by: Sandeep Kumar Thakur <thakur@xilinx.com>
Signed-off-by: Sibasish Rout <sibasish@xilinx.com>

#### Problem solved by the commit
Both VMC and SC won't poll the I2C main sensors at a time  

#### Bug/issue (if any) fixed, which PR introduced the bug, how it was discovered

https://jira.xilinx.com/browse/CR-1126641

#### How the problem was solved, alternative solutions (if any), and why they were rejected

until a  valid communication is established between VMC and SC, VMC stops polling the I2C main sensors

#### Risks (if any) associated with the changes in the commit
NA
#### What has been tested and how to request additional testing if necessary
verified with both legacy and Discovery  SC. 
- with legacy SC,  VMC stops polling the I2C main sensors 
- with Discovery SC,  VMC  polling the I2C main sensors
- in both above cases SC update has been tested.
#### Documentation impact (if any)
NA