### PR TITLE
CR-1122849 Improve robustness of upgrade by defaulting reset to 

### DIFF
--- a/vmr/src/common/cl_xgq_server.c
+++ b/vmr/src/common/cl_xgq_server.c
@@ -119,8 +119,10 @@ int cl_msg_handle_complete(cl_msg_t *msg)
 			msg->multiboot_payload.boot_on_backup;
 		cmd_cq->cq_vmr_payload.boot_on_recovery =
 			msg->multiboot_payload.boot_on_recovery;
-		cmd_cq->cq_vmr_payload.multi_boot_offset =
-			msg->multiboot_payload.multi_boot_offset;
+		cmd_cq->cq_vmr_payload.current_multi_boot_offset =
+			msg->multiboot_payload.current_multi_boot_offset;
+		cmd_cq->cq_vmr_payload.boot_on_offset =
+			msg->multiboot_payload.boot_on_offset;
 
 		cmd_cq->cq_vmr_payload.has_extfpt =
 			msg->multiboot_payload.has_extfpt;

--- a/vmr/src/common/xgq_cmd_common.h
+++ b/vmr/src/common/xgq_cmd_common.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021, Xilinx Inc
+ *  Copyright (C) 2021-2022, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -166,7 +166,8 @@ enum xgq_cmd_page_id {
  * @count:	[30-16]	number of bytes representing packet payload
  * @state:	[31]	flag indicates this is a new entry
  * @cid:		unique command id
- * @rsvd, rsvd1:	reserved for future use
+ * @rsvd:	        reserved for future use
+ * @cu_domain:	[3-0]	CU domain for certain start CU op codes
  * @cu_idx:	[11-0]	CU index for certain start CU op codes
  *
  * Any command in XGQ submission queue shares same command header.
@@ -187,7 +188,7 @@ struct xgq_cmd_sq_hdr {
 				uint16_t rsvd;
 				struct {
 					uint16_t cu_idx:12;
-					uint16_t rsvd1:4;
+					uint16_t cu_domain:4;
 				};
 			};
 		};

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -287,10 +287,11 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t ps_is_ready:1;
 	uint16_t pl_is_ready:1;
 	uint16_t resvd1:5;
-	uint16_t multi_boot_offset;
+	uint16_t current_multi_boot_offset;
 	uint32_t debug_level:3;
 	uint32_t program_progress:7;
-	uint32_t resvd2:22;
+	uint16_t resvd2:6;
+	uint16_t boot_on_offset;
 };
 
 /*

--- a/vmr/src/include/cl_msg.h
+++ b/vmr/src/include/cl_msg.h
@@ -100,7 +100,8 @@ struct xgq_vmr_multiboot_payload {
 	uint16_t has_ext_scfw:1;
 	uint16_t has_ext_sysdtb:1;
 	uint16_t rsvd:7;
-	uint16_t multi_boot_offset;
+	uint16_t current_multi_boot_offset;
+	uint16_t boot_on_offset;
 	uint32_t default_partition_offset;
 	uint32_t default_partition_size;
 	uint32_t backup_partition_offset;

--- a/vmr/src/rmgmt/rmgmt_common.h
+++ b/vmr/src/rmgmt/rmgmt_common.h
@@ -48,6 +48,7 @@ struct rmgmt_handler {
 	u32 rh_data_size;
 	u8  *rh_data; 	/* static malloc and never free */
 	bool rh_already_flashed; /* enforce reset/reboot after successfully flashed */
+	u32 rh_boot_on_offset;
 };
 
 static void inline axigate_freeze()
@@ -70,4 +71,5 @@ static void inline ucs_start()
 	IO_SYNC_WRITE32(0x1, VMR_EP_UCS_SHUTDOWN);
 }
 
+u32 rmgmt_boot_on_offset();
 #endif


### PR DESCRIPTION
backup PDI for vck5000 discovery

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

As we discussed before. just enable the POR on every vmr start time.
I don't change the behavior of A/B boot since the warm reboot behavior will be changed if we set B boot by default.

I also removed the hardcode 0xc0.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

CR-1122849

#### How problem was solved, alternative solutions (if any) and why they were rejected

see above description.

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

Tested with base2 shell, performed
1) hot reset to A
2) hot reset to B
3) check vmr_verbose_info is correct
4) when VMR stuck, hot reset can still be issued and boot to B

#### Documentation impact (if any)

N/A