### PR TITLE
CR-1121201 Prevent consecutive xbmgmt programs on VCK5000 discovery

### DIFF
--- a/vmr/src/rmgmt/rmgmt_common.h
+++ b/vmr/src/rmgmt/rmgmt_common.h
@@ -47,7 +47,7 @@ struct rmgmt_handler {
 	u32 rh_max_size;
 	u32 rh_data_size;
 	u8  *rh_data; 	/* static malloc and never free */
-	bool rh_apu_is_ready;
+	bool rh_already_flashed; /* enforce reset/reboot after successfully flashed */
 };
 
 static void inline axigate_freeze()

--- a/vmr/src/rmgmt/rmgmt_xfer.c
+++ b/vmr/src/rmgmt/rmgmt_xfer.c
@@ -175,15 +175,14 @@ static int rmgmt_init_xfer_handler(struct rmgmt_handler *rh)
 
 int rmgmt_init_handler(struct rmgmt_handler *rh)
 {
-	//rh->rh_base = OSPI_VERSAL_BASE;
-
 	rh->rh_max_size = BITSTREAM_SIZE; /* 32M */
-	//rh->rh_data = (u8 *)malloc(rh->rh_max_size);
 	rh->rh_data = (u8 *)pvPortMalloc(rh->rh_max_size);
 	if (rh->rh_data == NULL) {
 		RMGMT_LOG("pvPortMalloc %d bytes failed\r\n", rh->rh_data_size);
 		return -1;
 	}
+	
+	rh->rh_already_flashed = false;
 
 	/* ospi flash should alreay be initialized */
 	RMGMT_LOG("done");


### PR DESCRIPTION
without PDI reload

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Had this conversation with Shane, we agreed that we can simply just avoid having **2 consecutive updates.**

What we should allow
the same PDI to be written to both A and B provided it has already booted once - i.e. --force would allow the same PDI to be flashed again but only if it is running. We need this to replace a bad backup without needing two unique new PDIs.
What we should not allow
Two consecutive updates (either the same or different PDIs) if the first update was never booted

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

CR-1121201

#### How problem was solved, alternative solutions (if any) and why they were rejected

see description please

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

Tested on base2 shell. consecutive program will be blocked and request user to flash the shell.

#### Documentation impact (if any)

N/A