### PR TITLE
Removed unused code:

### DIFF
--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -430,16 +430,6 @@ static inline u32 check_firewall()
 	return IS_FIRED(read_firewall());
 }
 
-static inline u32 check_clock_shutdown_status()
-{
-	u32 shutdown_status = 0 ;
-
-	//offset to read shutdown status
-	shutdown_status = IO_SYNC_READ32(VMR_EP_UCS_CONTROL_STATUS_BASEADDR);
-
-	return (shutdown_status & 0x01);
-}
-
 int cl_xgq_pl_is_ready()
 {
 	return !check_firewall();


### PR DESCRIPTION
	check_clock_shutdown_status() moved to common layer , Not required in rmgmt_main.c

Signed-off-by : Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

#### Problem solved by the commit
NA
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
With PR#106 introduced unused code. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
NA
#### Documentation impact (if any)
NA