### PR TITLE
Fix for CR-1129142

### DIFF
--- a/vmr/src/include/cl_uart_rtos.h
+++ b/vmr/src/include/cl_uart_rtos.h
@@ -27,6 +27,7 @@ typedef enum _UART_STATUS{
 	UART_ERROR_INIT = -1,
 	UART_ERROR_SEMAPHORE = -2,
 	UART_ERROR_EVENT = -3,
+	UART_ERROR_TIMEOUT = -4,
 	UART_ERROR_GENERIC = -100,
 }UART_STATUS;
 
@@ -45,6 +46,7 @@ typedef struct _uart_rtos_handle_t{
 	EventGroupHandle_t 	rxEvent;
 	EventGroupHandle_t 	txEvent;
 	uart_rtos_cb_t 		cb_msg;
+	u8			uart_IRQ_ID;
 }uart_rtos_handle_t;
 
 typedef struct _uart_rtos_config_t{

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -67,49 +67,49 @@ static void pVMCTask(void *params)
     /* Retry till fan controller is programmed */
     while (max6639_init(1, 0x2E));  // only for vck5000
 
-    /* Create SC update task */
-    SC_Update_Task_Create();
-
-	/* vmc_sensor_monitoring_lock */
+    /* vmc_sensor_monitoring_lock */
     vmc_sensor_monitoring_lock = xSemaphoreCreateMutex();
-	if(vmc_sensor_monitoring_lock == NULL){
-		VMC_ERR("vmc_sensor_monitoring_lock creation failed \n\r");
-	}
-
-    /* Start Sensor Monitor task */
-
-    if (xTaskCreate( SensorMonitorTask,
-		( const char * ) "Sensor_Monitor",
-		TASK_STACK_DEPTH,
-		NULL,
-		tskIDLE_PRIORITY + 1,
-		&xSensorMonTask
-		) != pdPASS) {
-	CL_LOG(APP_VMC,"Failed to Create Sensor Monitor Task \n\r");
-	return ;
+    if(vmc_sensor_monitoring_lock == NULL){
+        VMC_ERR("vmc_sensor_monitoring_lock creation failed \n\r");
     }
 
     /* vmc_sc_lock */
     vmc_sc_lock = xSemaphoreCreateMutex();
     if(vmc_sc_lock == NULL){
-    VMC_ERR("vmc_sc_lock creation failed \n\r");
+	VMC_ERR("vmc_sc_lock creation failed \n\r");
     }
 
-	/* vmc_sc_comms_lock */
+    /* vmc_sc_comms_lock */
     vmc_sc_comms_lock = xSemaphoreCreateMutex();
-	if(vmc_sc_comms_lock == NULL){
-		VMC_ERR("vmc_sc_comms_lock creation failed \n\r");
-	}
+    if(vmc_sc_comms_lock == NULL){
+	VMC_ERR("vmc_sc_comms_lock creation failed \n\r");
+    }
+
+    /* Create SC update task */
+    SC_Update_Task_Create();
+
+    /* Start Sensor Monitor task */
+
+    if (xTaskCreate( SensorMonitorTask,
+	( const char * ) "Sensor_Monitor",
+	TASK_STACK_DEPTH,
+	NULL,
+	tskIDLE_PRIORITY + 1,
+	&xSensorMonTask
+	) != pdPASS) {
+		CL_LOG(APP_VMC,"Failed to Create Sensor Monitor Task \n\r");
+		return ;
+    }
 
     if (xTaskCreate( VMC_SC_CommsTask,
-		( const char * ) "VMC_SC_Comms",
-		TASK_STACK_DEPTH,
-		NULL,
-		tskIDLE_PRIORITY + 1,
-		&xVMCSCTask
-		) != pdPASS) {
-	CL_LOG(APP_VMC,"Failed to Create VMCSC Monitor Task \n\r");
-	return ;
+	( const char * ) "VMC_SC_Comms",
+	TASK_STACK_DEPTH,
+	NULL,
+	tskIDLE_PRIORITY + 1,
+	&xVMCSCTask
+	) != pdPASS) {
+		CL_LOG(APP_VMC,"Failed to Create VMCSC Monitor Task \n\r");
+		return ;
     }
 
 
@@ -119,14 +119,14 @@ static void pVMCTask(void *params)
 int VMC_Launch( void )
 {
     if (xTaskCreate( pVMCTask,
-		( const char * ) "VMC",
-		TASK_STACK_DEPTH,
-		NULL,
-		tskIDLE_PRIORITY + 1,
-		&xVMCTask
-		) != pdPASS) {
-	CL_LOG(APP_VMC,"Failed to Create VMC Task \n\r");
-	return -1;
+	( const char * ) "VMC",
+	TASK_STACK_DEPTH,
+	NULL,
+	tskIDLE_PRIORITY + 1,
+	&xVMCTask
+	) != pdPASS) {
+		CL_LOG(APP_VMC,"Failed to Create VMC Task \n\r");
+		return -1;
     }
 
     return 0;


### PR DESCRIPTION
Address some issues reported in the CR
Made some improvement to the code around UART_RTOS driver, VMC_SC_COMM, cl_msg_handle_init.

Signed-off-by: Shahab Alilou <shahaba@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Memory corruption
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1129142
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Ran vmr.sh test which periodically runs xbutil validate , xbutil reset, xbutil examine. So far system hasn't crashed out. It's been running on CentOS since last Friday.
#### Documentation impact (if any)
