### PR TITLE
CR-1122849 Improve robustness of upgrade by defaulting reset to backup

### DIFF
--- a/build/build.json
+++ b/build/build.json
@@ -1,5 +1,5 @@
 {
-  "CONF_BUILD_TA" : "2022.1_0406_1",
+  "CONF_BUILD_TA" : "2022.1_0428_1",
   "CONF_BUILD_XSA" : "/opt/xilinx/platforms/xilinx_vck5000_gen4x8_xdma_2_202210_1/hw/xilinx_vck5000_gen4x8_xdma_2_202210_1.xsa",
   "CONF_BUILD_XSABIN" : "/opt/xilinx/firmware/vck5000/gen4x8-xdma/base/partition.xsabin",
   "CONF_BUILD_PLATFORM" : "platform_2022.1_vitis.json",

--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -740,8 +740,8 @@ static void pvXGQTask( void *pvParameters )
 	rh.rh_boot_on_offset = IO_SYNC_READ32(VMR_EP_PLM_MULTIBOOT);
 	RMGMT_WARN("boot on 0x%x", rh.rh_boot_on_offset);
 
-	/* init pmc power on reset (POR), so that hot reset will be engaged */
-	rmgmt_enable_boot_backup(&msg);
+	/* enforce next boot to default image */
+	rmgmt_enable_boot_default(&msg);
 
 	for ( ;; )
 	{


### PR DESCRIPTION
PDI for vck5000 discovery

Rollback to boot on default behavior. Setting boot on backup by default
is problematic for now.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

always start from default boot offset with correct POR setting.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1122849

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit

It requires the default image can be loaded when release the shell. Otherwise, there is no way to set the boot image to backup image.

#### What has been tested and how, request additional testing if necessary
1. xbutil reset
2. stop vmr, xbutil reset
3. xbutil reset to backup

```
root@xsjdavidz01:~# xbmgmt examine -d 84:0 -r vmr --verbose
Verbose: Enabling Verbosity
Verbose: SubCommand: examine

-------------------------------------------------------
1/1 [0000:84:00.0] : xilinx_vck5000_gen4x8_xdma_base_2
-------------------------------------------------------
Vmr Status
  Build flags          :  default full build
  Vitis version        :  2022.1_daily_latest
  Git hash             :  dadf034abf0d45373fca404739a2271663df5cf0
  Git branch           :  multiboot
  Git hash date        :  Thu, 28 Apr 2022 12
  Vmr build date       :  Thu Apr 28 12
  Vmr build version    :  0.0.0.0
  Is ps ready          :  0
  Default image offset :  0x48000
  Default image size   :  0x6f13a0
  Default image capacity :  0x5fb8000
  Backup image offset  :  0x6008000
  Backup image size    :  0x6f1510
  Backup image capacity :  0x5fb8000
  Sc firmware size     :  0x630f0
  Has fpt              : 1
  Has fpt recovery     : 1
  Boot on default      : 1
  Boot on backup       : 0
  Boot on recovery     : 0
  Current multi boot offset : 0x9
  Boot on offset       : 0x9
  Has extfpt           : 1
  Has ext meta xsabin  : 1
  Has ext sc fw        : 1
  Has ext system dtb   : 1
  Debug level          : 0
  Program progress     : 0
  Pl is ready          : 1
  Ps is ready          : 0
```

#### Documentation impact (if any)
N/A