### PR TITLE
Fix for CR-1128590

### DIFF
--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -53,12 +53,13 @@
 #define VCCINT_NAME    "vccint\0"
 
 SDR_t *sdrInfo;
-SemaphoreHandle_t sdr_lock;
+extern SemaphoreHandle_t sdr_lock;
 static u8 asdmInitSuccess = false;
 extern Versal_BoardInfo board_info;
 extern SC_VMC_Data sc_vmc_data;
 extern u8 fpt_sc_version[3];
 
+void Asdm_Update_Active_MSP_sensor();
 extern s8 Temperature_Read_Inlet(snsrRead_t *snsrData);
 extern s8 Temperature_Read_Outlet(snsrRead_t *snsrData);
 extern s8 Temperature_Read_Board(snsrRead_t *snsrData);
@@ -866,14 +867,6 @@ s8 Init_Asdm()
 	return -1;
     }
 
-    /* sdr_lock */
-    sdr_lock = xSemaphoreCreateMutex();
-    if(sdr_lock == NULL){
-	VMC_ERR("sdr_lock creation failed \n\r");
-	return XST_FAILURE;
-    }
-
-
     asdmInitSuccess = true;
     VMC_LOG("ASDM Init success !!\n\r");
 
@@ -1170,6 +1163,9 @@ void Monitor_Sensors(void)
 
     if(asdmInitSuccess == true)
     {
+        /* Update the MSP FW version */
+        Asdm_Update_Active_MSP_sensor();
+
 		for(sdrIndex = 0; sdrIndex < MAX_SDR_REPO ; sdrIndex++)
 		{
 			Asdm_SensorRecord_t *sensorRecord = sdrInfo[sdrIndex].sensorRecord;
@@ -1295,7 +1291,13 @@ u8 Asdm_Send_I2C_Sensors_SC(u8 *scPayload)
 	    return 0;
 	}
 
-	 Asdm_SensorRecord_t *sensorRecord = sdrInfo[tempSensorIdx].sensorRecord;
+	if(false == asdmInitSuccess)
+	{
+	    VMC_ERR("Asdm not yet Initialized !! \n\r");
+	    return 0;
+	}
+
+	Asdm_SensorRecord_t *sensorRecord = sdrInfo[tempSensorIdx].sensorRecord;
 	/* We need to Send all the Temperature sensors to SC for OOB */
 	for(i = 0 ; i< sdrInfo[tempSensorIdx].header.no_of_records; i++)
 	{

--- a/vmr/src/vmc/vmc_sc_comms.c
+++ b/vmr/src/vmc/vmc_sc_comms.c
@@ -29,11 +29,9 @@ u16 g_scDataCount = 0;
 bool isPacketReceived;
 u8 scPayload[128] = {0};
 
-static volatile bool isVMCActive  = false ;
-volatile bool isPowerModeActive ;
-volatile bool getSensorRespLen ;
-
-extern uint8_t sc_update_flag;
+static volatile bool is_SC_active  = false ;
+volatile bool isPowerModeActive = false;
+volatile bool getSensorRespLen = false;
 
 u8 VMC_SC_Comms_Msg[] = {
        MSP432_COMMS_VOLT_SNSR_REQ,
@@ -45,7 +43,6 @@ u8 VMC_SC_Comms_Msg[] = {
 #define MAX_MSGID_COUNT     (sizeof(VMC_SC_Comms_Msg)/sizeof(VMC_SC_Comms_Msg[0]))
 
 extern u8 Asdm_Send_I2C_Sensors_SC(u8 *scPayload);
-extern void Asdm_Update_Active_MSP_sensor();
 
 static uint16_t calculate_checksum(vmc_sc_uart_cmd *data)
 {
@@ -65,12 +62,12 @@ static uint16_t calculate_checksum(vmc_sc_uart_cmd *data)
 
 bool vmc_get_sc_status()
 {
-	return isVMCActive;
+	return is_SC_active;
 }
 
 void vmc_set_sc_status(bool value)
 {
-	isVMCActive = value;
+	is_SC_active = value;
 }
 
 u16 vmcU8ToU16(u8 *payload) {
@@ -103,23 +100,18 @@ void VMC_Update_Sensor_Length(u16 length,u8 *payload)
 void VMC_Update_Version_PowerMode(u16 length,u8 *payload)
 {
 	u16 i=0;
-	static u8 isActiveMSPVerUpdated = false;
+
 	for(i=0; i<length;)
 	{
 		switch(payload[i])
 		{
+		
 		case BMC_VERSION:
 			sc_vmc_data.scVersion[0] = payload[i+2];  // fw_version
 			sc_vmc_data.scVersion[1] = payload[i+3];  // fw_rev_major
 			sc_vmc_data.scVersion[2] = payload[i+4];  // fw_rev_minor
-			/* Update the ASDM Active MSP Version */
-			if((isActiveMSPVerUpdated == false) &&
-					(sc_vmc_data.scVersion[0] != 0))
-			{
-				Asdm_Update_Active_MSP_sensor();
-				isActiveMSPVerUpdated = true;
-			}
 			break;
+		
 		case TOTAL_POWER_AVAIL:
 			sc_vmc_data.availpower = payload[i+2];
 			break;

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -624,11 +624,6 @@ void SensorMonitorTask(void *params)
 
     VMC_LOG(" Sensor Monitor Task Created !!!\n\r");
 
-    if(Init_Asdm())
-    {
-         VMC_ERR(" ASDM Init Failed \n\r");
-    }
-
     if (xgq_sensor_flag == 0 &&
         cl_msg_handle_init(&sensor_hdl, CL_MSG_SENSOR, xgq_sensor_cb, NULL) == 0) {
         VMC_LOG("init sensor handle done.");


### PR DESCRIPTION
- Moved sdr_lock to vmc_main and made some improvements in the code.

Signed-off-by: Shahab Alilou <shahaba@amd.com>
Signed-off-by: Sandeep Kumar Thakur <sandeep.thakur@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
With the fix we would not observe VMR hang.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1128590

#### How problem was solved, alternative solutions (if any) and why they were rejected
There was a piece of code, that was trying to access a object even before its initialization.
We moved the initialization of the object to vmc_main() and made sure to block any other such
Possible unwanted access.

#### Risks (if any) associated the changes in the commit
N.A
#### What has been tested and how, request additional testing if necessary
1. We have ran xbutil reset followed by xbutil validate in a loop for over 34 hours without any issues or assert observed.
2. Manually induce 10 secs delay in Sensor Monitoring, we do not see any hang with the fix.

#### Documentation impact (if any)
N.A