### PR TITLE
Fix for CR-1127376

### DIFF
--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -344,9 +344,9 @@ s8 Power_Monitor(snsrRead_t *snsrData)
     if (xSemaphoreTake(vmc_sc_lock, portMAX_DELAY))
     {
     	power_mode =  sc_vmc_data.availpower;
-    	pexPower = ((sc_vmc_data.sensor_values[PEX_12V]/1000) * (sc_vmc_data.sensor_values[PEX_12V_I_IN])/1000);
-    	aux0Power = ((sc_vmc_data.sensor_values[AUX_12V]/1000) * (sc_vmc_data.sensor_values[V12_IN_AUX0_I])/1000); //2x4 AUX
-    	aux1Power = ((sc_vmc_data.sensor_values[AUX1_12V]/1000) * (sc_vmc_data.sensor_values[V12_IN_AUX1_I])/1000); //2x3 AUX
+    	pexPower = ((sc_vmc_data.sensor_values[PEX_12V]/1000.0) * (sc_vmc_data.sensor_values[PEX_12V_I_IN])/1000.0);
+    	aux0Power = ((sc_vmc_data.sensor_values[AUX_12V]/1000.0) * (sc_vmc_data.sensor_values[V12_IN_AUX0_I])/1000.0); //2x4 AUX
+    	aux1Power = ((sc_vmc_data.sensor_values[AUX1_12V]/1000.0) * (sc_vmc_data.sensor_values[V12_IN_AUX1_I])/1000.0); //2x3 AUX
     	totalPower = (pexPower + aux0Power +aux1Power);
     	xSemaphoreGive(vmc_sc_lock);
     }
@@ -357,7 +357,8 @@ s8 Power_Monitor(snsrRead_t *snsrData)
 
     if(totalPower != 0)
     {
-	u16 roundedOffVal = (totalPower > 0) ? totalPower : 0;
+    	/* Adding 0.5 to round off the totalPower to nearest integer.*/
+        u16 roundedOffVal = (totalPower + 0.5);
         Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(roundedOffVal),&roundedOffVal,sizeof(roundedOffVal));
         snsrData->sensorValueSize = sizeof(roundedOffVal);
         snsrData->snsrSatus = Vmc_Snsr_State_Normal;


### PR DESCRIPTION
	- TotalPower is now Rounded off to the nearest integer.

Signed-off-by: Himasagar Reddy <himasaga@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
total power is Rounded off to the nearest integer
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1127376?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

#### How problem was solved, alternative solutions (if any) and why they were rejected
previously the decimal values are not stored in the variables. with these change, variables has the decimal 
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
 Compared  the values received by SC and the one after calculating the total power
#### Documentation impact (if any)
NA