### PR TITLE
CR-1130374 query vmr_status while xbmgmt program -b might timeout

### DIFF
--- a/vmr/src/common/cl_xgq_server.c
+++ b/vmr/src/common/cl_xgq_server.c
@@ -402,7 +402,7 @@ static int submit_to_queue(u32 sq_addr)
 			convert_control_type(sq->vmr_control_payload.req_type);
 		msg.multiboot_payload.vmr_debug_type = 
 			convert_debug_type(sq->vmr_control_payload.debug_type);
-		ret = dispatch_to_queue(&msg, TASK_SLOW);
+		ret = dispatch_to_queue(&msg, TASK_QUICK);
 		break;
 	case CL_MSG_CLOCK:
 		msg.clock_payload.ocl_region = sq->clock_payload.ocl_region;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
we should not put pdi flash and vmr_status request in the same message queue, the vmr_status request can take longer due to pdi flash is not finished.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1130374 
#### How problem was solved, alternative solutions (if any) and why they were rejected
should put vmr_status into another queue

#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
tested with latest shell

#### Documentation impact (if any)
N/A