### PR TITLE
Address some of Coverity issues

### DIFF
--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -194,6 +194,6 @@ void EepromDump(void);
 * @note None
 **
 ******************************************************************************/
-u8 Versal_EEPROM_ReadBoardIno(void);
+u8 Versal_EEPROM_ReadBoardInfo(void);
 
 #endif /* INC_VMC_API_H_ */

--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -1336,7 +1336,7 @@ u8 Asdm_Send_I2C_Sensors_SC(u8 *scPayload)
 void Asdm_Update_Active_MSP_sensor()
 {
 	s8 boardInfoSensorIdx = getSDRIndex(BoardInfoSDR);
-	u8 idx = 0;
+	s8 idx = 0;
 
 	Asdm_SensorRecord_t *sensorRecord = sdrInfo[boardInfoSensorIdx].sensorRecord;
 	for(idx = sdrInfo[boardInfoSensorIdx].header.no_of_records -1 ; idx >= 0 ; idx--)

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -63,7 +63,7 @@ static void pVMCTask(void *params)
 #endif
 
     /* Read the EEPROM */
-    Versal_EEPROM_ReadBoardIno();
+    Versal_EEPROM_ReadBoardInfo();
 
     /* Retry till fan controller is programmed */
     while (max6639_init(1, 0x2E));  // only for vck5000

--- a/vmr/src/vmc/vmc_update_sc.c
+++ b/vmr/src/vmc/vmc_update_sc.c
@@ -362,6 +362,7 @@ void VMC_Parse_Fpt_SC_Version(u32 addr_location, u8 *versionbuff)
 			break;
 
 		default:
+			VMC_ERR("\n\rMust not come here.\r\n");
 			break;
 
 		}
@@ -513,6 +514,7 @@ void VMC_Parse_Fpt_SC(u32 addr_location, u8 *bsl_send_data_pkt, u16 *pkt_length)
 			break;
 
 		default:
+			VMC_ERR("\n\rMust not come here.\r\n");
 			break;
 
 		}


### PR DESCRIPTION
CID: 122398-122404-122410-122414-122435-122443-122445

Signed-off-by: Shahab Alilou <shahaba@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Coverity issues
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Ran vmr.sh for over 250 minutes and printed out xbutil examine reports:

Pcie Info
  Vendor                 : 0x10ee
  Device                 : 0x5049
  Sub Device             : 0x000e
  Sub Vendor             : 0x10ee
  PCIe                   : Gen3x8
  DMA Thread Count       : 2
  CPU Affinity           : 0-3
  Shared Host Memory     : 0 Byte
  Max Shared Host Memory : 0 Byte
  Enabled Host Memory    : 0

Platform
  XSA Name               : xilinx_vck5000_gen4x8_xdma_base_2
  Platform UUID          : 04624343-B44B-B0A1-3CD4-8A411789FF20
  FPGA Name              :
  JTAG ID Code           : 0x0
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : false
  P2P Status             : not supported

Mac Addresses            : 00:0A:35:0C:F6:3A
                         : 00:0A:35:0C:F6:3B

CMC
  Status : 0x0 (GOOD)
  Runtime Clock Scaling :
    Not supported
Electrical
  Max Power              : NA Watts
  Power                  : 18 Watts
  Power Warning          : NA

  Power Rails            : Voltage   Current
  12v_pex                : 12.317 V,  0.797 A
  3v3_pex                :  3.306 V
  3v3_aux                :  3.416 V
  12v_aux_0              : 12.269 V,  0.515 A
  12v_aux_1              : 12.291 V,  0.320 A
  vccint                 :  0.805 V, 76.000 A

Firewall
  Level -- --: -- --

Mailbox
  Total bytes received   : 9120960 Bytes
  Unknown                : 0
  Test msg ready         : 0
  Test msg fetch         : 0
  Lock bitstream         : 0
  Unlock bitstream       : 0
  Hot reset              : 0
  Firewall trip          : 0
  Download xclbin kaddr  : 0
  Download xclbin        : 0
  Reclock                : 0
  Peer data read         : 0
  User probe             : 0
  Mgmt state             : 161
  Change shell           : 0
  Reprogram shell        : 0
  P2P bar addr           : 0
                         : 0

Mechanical
  Fans
    Not present

  Primary                : N/A
  Recovery               : N/A

Thermals
  Temperature            : Celcius
  PCB                    :     44 C
  device                 :     65 C
  vccint                 :     56 C
  cage_temp_0            :      0 C
  cage_temp_1            :      0 C

#### Documentation impact (if any)
