### PR TITLE
Fix for CR-1130638

### DIFF
--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -62,6 +62,9 @@ extern uart_rtos_handle_t uart_vmcsc_log;
 #define MSP432_COMMS_MSG_GOOD           (0xFE)
 #define MSP432_COMMS_MSG_ERR            (0xFF)
 
+#define MSP432_COMMS_MSG_GOOD_LEN       (0x0A)
+#define MSP432_COMMS_MSG_ERR_LEN        (0x0B)
+
 #define MSP432_COMMS_OEM_CMD_REQ        (0x6F)
 #define MSP432_COMMS_OEM_CMD_RESP       (0xEF)
 #define PAYLOAD_SIZE_OEM_ID_RESP        (0x04)

--- a/vmr/src/vmc/vmc_update_sc.c
+++ b/vmr/src/vmc/vmc_update_sc.c
@@ -562,7 +562,7 @@ upgrade_status_t matchCRC_postWrite(unsigned int writeAdd)
 	}
 	else
 	{
-		if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_CRC_RESP, &receivedByteCount,RCV_TIMEOUT_MS(200)) != UART_SUCCESS )
+		if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_CRC_RESP, &receivedByteCount,RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 		{
 			VMC_ERR("Uart Receive Failure \r\n");
 		}
@@ -649,7 +649,7 @@ void SCUpdateTask(void * arg)
 					}
 					else
 					{
-						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], SC_BSL_SYNCED_RESP, &receivedByteCount, RCV_TIMEOUT_MS(200)) != UART_SUCCESS )
+						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], SC_BSL_SYNCED_RESP, &receivedByteCount, RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 						{
 							retryCount +=1;
 							VMC_ERR("Uart Receive Failure.. Retrying !! \r\n");
@@ -713,7 +713,7 @@ void SCUpdateTask(void * arg)
 					}
 					else
 					{
-						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], SC_ENABLE_BSL_RESP, &receivedByteCount, RCV_TIMEOUT_MS(200)) != UART_SUCCESS )
+						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], SC_ENABLE_BSL_RESP, &receivedByteCount, RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 						{
 							retryCount +=1;
 							VMC_ERR("Uart Receive Failure.. Retrying !! \r\n");
@@ -764,7 +764,7 @@ void SCUpdateTask(void * arg)
 					}
 					else
 					{
-						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_SYNCED_RESP, &receivedByteCount,RCV_TIMEOUT_MS(100)) != UART_SUCCESS )
+						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_SYNCED_RESP, &receivedByteCount,RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 						{
 							retryCount +=1;
 							VMC_ERR("Uart Receive Failure.. Retrying !! \r\n");
@@ -817,7 +817,7 @@ void SCUpdateTask(void * arg)
 					}
 					else
 					{
-						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_UNLOCK_PASSWORD_RESP, &receivedByteCount,RCV_TIMEOUT_MS(200)) != UART_SUCCESS )
+						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_UNLOCK_PASSWORD_RESP, &receivedByteCount,RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 						{
 							retryCount +=1;
 							VMC_ERR("Uart Receive Failure.. Retrying !! \r\n");
@@ -876,7 +876,7 @@ void SCUpdateTask(void * arg)
 					}
 					else
 					{
-						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_MASS_ERASE_RESP, &receivedByteCount,RCV_TIMEOUT_MS(200)) != UART_SUCCESS )
+						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_MASS_ERASE_RESP, &receivedByteCount,RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 						{
 							retryCount +=1;
 							VMC_ERR("Uart Receive Failure \r\n");
@@ -978,7 +978,7 @@ void SCUpdateTask(void * arg)
 							}
 							else
 							{
-								if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_DATA_TX_32_RESP, &receivedByteCount,RCV_TIMEOUT_MS(200)) != UART_SUCCESS )
+								if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_DATA_TX_32_RESP, &receivedByteCount,RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 								{
 									VMC_ERR("Uart Receive Failure \r\n");
 								}
@@ -1137,7 +1137,7 @@ void SCUpdateTask(void * arg)
 					}
 					else
 					{
-						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_VERSION_RESP, &receivedByteCount,RCV_TIMEOUT_MS(200)) != UART_SUCCESS )
+						if( UART_RTOS_Receive(&uart_vmcsc_log, &receive_bufr[0], BSL_VERSION_RESP, &receivedByteCount,RCV_TIMEOUT_MS(500)) != UART_SUCCESS )
 						{
 							retryCount +=1;
 							VMC_ERR("Uart Receive Failure \r\n");

--- a/vmr/src/vmc/vmc_update_sc.h
+++ b/vmr/src/vmc/vmc_update_sc.h
@@ -37,7 +37,8 @@
 #define BSL_CRC_SUCCESS_RESP			(0x3A)
 #define BSL_SYNC_SUCCESS				(0x00)
 #define SC_BSL_SYNCED_REQ				(0x01)
-#define SC_BSL_SYNCED_RESP				(0x02)
+/* Size of comms error message response */
+#define SC_BSL_SYNCED_RESP				(0x0B)
 
 #define SC_ENABLE_BSL_REQ				(0x09)
 #define SC_ENABLE_BSL_RESP				(0x0A)


### PR DESCRIPTION
	- Fixed SC update issue.

Signed-off-by: Sibasish Rout <sibasish@xilinx.com>
Signed-off-by: Sandeep Kumar Thakur <thakur@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixed a problem with SC update, as well as unnecessary uart timeouts when using an unsupported SC.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1130638
#### How problem was solved, alternative solutions (if any) and why they were rejected
There was an expected byte mismatch for the SC update. We have modified that. 
We added logic that checks whether VMR is communicating with an unsupported SC so that we can parse the error message. 
With this, VMR will be able to handle responses from both supported and unsupported SC FW. 
Without this change, in the case of unsupported SC, COMMS requests would continuously time out after every 500 msec because VMC expects a message GOOD response for each request, which legacy SC does not support.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
1. We ran "xbutil reset" followed by "xbutil validate" in a loop for approximately 10 hours without encountering any problems or asserts.
2. SC was updated more than 200 times without any issues. The update works fine for both Legacy -> Discovery SC and Discovery -> Discovery SC.
3. Tried both the ipmitool chassis power cycle and the AC power cycle after each upgrade to check the SC version with the "xbmgmt platform" command.
4. Checked for OOB sensor data on Idrac/ILO.
5. Verified all sensor data from the "xbutil examine" command after each update.
#### Documentation impact (if any)
NA