### PR TITLE
CR-1130694 vmr_202210.2.13.186 cannot be used to build the

### DIFF
--- a/build/build.json
+++ b/build/build.json
@@ -1,5 +1,5 @@
 {
-  "CONF_BUILD_TA" : "2022.1_0428_1",
+  "CONF_BUILD_TA" : "2022.1_0512_1",
   "CONF_BUILD_XSA" : "/opt/xilinx/platforms/xilinx_vck5000_gen4x8_xdma_2_202210_1/hw/xilinx_vck5000_gen4x8_xdma_2_202210_1.xsa",
   "CONF_BUILD_XSABIN" : "/opt/xilinx/firmware/vck5000/gen4x8-xdma/base/partition.xsabin",
   "CONF_BUILD_PLATFORM" : "platform_2022.1_vitis.json",

--- a/build/build_qdma.json
+++ b/build/build_qdma.json
@@ -1,0 +1,7 @@
+{
+  "CONF_BUILD_TA" : "2022.1_daily_latest",
+  "CONF_BUILD_XSA" : "/opt/xilinx/platforms/xilinx_vck5000_gen4x8_qdma_1_202210_1/hw/xilinx_vck5000_gen4x8_qdma_1_202210_1.xsa",
+  "CONF_BUILD_XSABIN" : "/opt/xilinx/firmware/vck5000/gen4x8-xdma/base/partition.xsabin",
+  "CONF_BUILD_PLATFORM" : "platform_2022.1_vitis.json",
+}
+

--- a/build/create_app.tcl
+++ b/build/create_app.tcl
@@ -1,6 +1,6 @@
 setws .
 puts "create app"
-set xsaName $::env(FORCE_MARK_XSA_NAME)
+set xsaName $::env(XSA_PLATFORM_NAME)
 puts "xsaName is: $xsaName"
 app create -name vmr -platform ${xsaName} -domain freertos10_xilinx_domain -template "Empty Application(C)"
 

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -1,2 +1,0 @@
-#export FORCE_MARK_AS_EDGE_XSA=1
-export FORCE_MARK_XSA_NAME=xilinx_vck5000_gen4x8_xdma_2_202210_1


### PR DESCRIPTION
xilinx-vck5000-gen4x8-qdma-base-1 platform

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

remove some hardcode and use a different way to get the platform name.
the vitis should give us a stable way to query the platform name anyway, but given it is not being fixed anytime soon, we can use this way to get the dynamic xsa name.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1130694
#### How problem was solved, alternative solutions (if any) and why they were rejected

dynamically query the xsa name for qdma or xdma

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested with both qdma and xdma xsa files
  588  ./build.sh -xsa /proj/rdi/staff/davidzha/share/xgq/qdma.xsa
  589  ./build.sh -xsa /proj/rdi/staff/davidzha/share/xgq/xdma.xsa 
#### Documentation impact (if any)
N/A