### PR TITLE
VITIS-5848 Resilient VMR - VMC

### DIFF
--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -18,7 +18,6 @@
 #include "xsysmonpsv.h"
 #include "vmc_sc_comms.h"
 #include "vmc_update_sc.h"
-#include "xgpio.h"
 
 /* Task Handles */
 static TaskHandle_t xVMCTask;
@@ -28,7 +27,6 @@ TaskHandle_t xVMCTaskMonitor;
 
 SemaphoreHandle_t sdr_lock;
 SemaphoreHandle_t vmc_sc_lock;
-SemaphoreHandle_t vmc_sc_comms_lock;
 SemaphoreHandle_t vmc_sensor_monitoring_lock;
 
 uart_rtos_handle_t uart_vmcsc_log;
@@ -67,16 +65,9 @@ static void pVMCTask(void *params)
     vmc_sc_lock = xSemaphoreCreateMutex();
     configASSERT(vmc_sc_lock != NULL);
 
-    /* vmc_sc_comms_lock */
-    vmc_sc_comms_lock = xSemaphoreCreateMutex();
-    configASSERT(vmc_sc_comms_lock != NULL);
-
     /* sdr_lock */
     sdr_lock = xSemaphoreCreateMutex();
     configASSERT(sdr_lock != NULL);
-
-    /* Create SC update task */
-    SC_Update_Task_Create();
 
     /* Init ASDM */
     if(Init_Asdm()) 

--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -290,4 +290,8 @@ bool Parse_SCData(u8 *Payload);
 bool VMC_send_packet(u8 Message_id , u8 Flags,u8 Payloadlength, u8 *Payload);
 bool vmc_get_sc_status();
 void vmc_set_sc_status(bool value);
+bool vmc_get_power_mode_status();
+void vmc_set_power_mode_status(bool value);
+bool vmc_get_snsr_resp_status();
+void vmc_set_snsr_resp_status(bool value);
 

--- a/vmr/src/vmc/vmc_update_sc.h
+++ b/vmr/src/vmc/vmc_update_sc.h
@@ -10,8 +10,10 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include "cl_msg.h"
 
-#define ULONG_MAX 						0xFFFFFFFFUL
+#define ULONG_MAX 					0xFFFFFFFFUL
+#define FW_UPDATE_TRIGGER_0				( 0x01UL )
 
 #define DELAY_MS(x)   					((x)     /portTICK_PERIOD_MS )
 #define RCV_TIMEOUT_MS(x)  				((x)     /portTICK_PERIOD_MS )
@@ -146,5 +148,7 @@ bool VMC_Read_SC_FW(void);
 u8 Get_SC_Checksum(void);
 u8 Check_Received_SC_Header(void *ptr1, void *ptr2, u8 len);
 upgrade_status_t matchCRC_postWrite(unsigned int writeAdd);
+void UpdateSCFW();
+void VMC_Get_Fpt_SC_Version(cl_msg_t *msg);
 
 #endif /* SRC_VMC_VMC_UPDATE_SC_H_ */


### PR DESCRIPTION
	- The SC update task has been merged with the SC comms task.
	- With this patch, a warm reboot should be sufficient to see an updated SC version on the "xbmgmt platform" command.

Signed-off-by: Sibasish Rout <sibasish.rout@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. The SC update task has been merged with the SC comms task.
2. With this patch, a warm reboot should be sufficient to see an updated SC version on the "xbmgmt platform" command.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-5848
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
1. We ran "xbutil reset" followed by "xbutil validate" in a loop for approximately 15 hours without encountering any problems or asserts.
3. SC was updated more than 20 times without any issues. The update works fine for both Legacy -> Discovery SC and Discovery -> Discovery SC.
4. Tried both the ipmitool chassis power cycle and the AC power cycle after each upgrade to check the SC version with the "xbmgmt platform" command.
5. Checked for OOB sensor data on Idrac/ILO.
6. Verified all sensor data from the "xbutil examine" command after each update.
#### Documentation impact (if any)
NA