### PR TITLE
Rename VMC <-> SC comms sensor

### DIFF
--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -253,7 +253,7 @@ typedef enum
     V12_IN_I,
     V12_IN_AUX0_I,
     V12_IN_AUX1_I,
-    VCCAUX,
+    VCCAUX_SC,
     VCCAUX_PMC,
     VCCRAM,
     POWER_GOOD = 0x46,


### PR DESCRIPTION
VCCAUX is available through SC and also through Sysmon in some boards.
Renaming appropriately.

Signed-off-by: Bhargava Sreekantappa Gayathri <bhargava.sreekantappa-gayathri@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1132335

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Building with V70 XSA

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
