### PR TITLE
Fix for CR-1128393

### DIFF
--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -10,6 +10,7 @@
 #include "vmc_sc_comms.h"
 #include "cl_mem.h"
 #include <semphr.h>
+#include "xsysmonpsv.h"
 
 #define ASDM_GET_SDR_SIZE_REQ (0x00)
 
@@ -101,9 +102,9 @@ void getCurrentNames(u8 index, char8* snsrName, u8 *sensorId)
     };
 
     struct sensorData snsrData[] =    {
-        { PEX_12V_I_IN,   "12v_pex\0"  },
-        { V12_IN_AUX0_I,  "12v_aux_0\0" },
-        { V12_IN_AUX1_I,  "12v_aux_1\0" },
+        { PEX_12V_I_IN_SC,   "12v_pex\0"  },
+        { V12_IN_AUX0_I_SC,  "12v_aux_0\0" },
+        { V12_IN_AUX1_I_SC,  "12v_aux_1\0" },
     };
 
     if(NULL != snsrName)
@@ -127,11 +128,11 @@ void getVoltagesName(u8 index, char8* snsrName, u8 *sensorId)
 
     struct sensorData voltageData[] =
     {
-        { PEX_12V,    "12v_pex\0" },
-        { PEX_3V3,    "3v3_pex\0" },
-        { AUX_3V3,     "3v3_aux\0" },
-        { AUX_12V,     "12v_aux_0\0" },
-        { AUX1_12V,    "12v_aux_1\0" }
+        { PEX_12V_SC,    "12v_pex\0" },
+        { PEX_3V3_SC,    "3v3_pex\0" },
+        { AUX_3V3_SC,     "3v3_aux\0" },
+        { AUX_12V_SC,     "12v_aux_0\0" },
+        { AUX1_12V_SC,    "12v_aux_1\0" }
     };
 
     if(NULL != snsrName)
@@ -154,8 +155,8 @@ void getQSFPName(u8 index, char8* snsrName, u8 *sensorId)
 
     struct sensorData qsfpData[] =
     {
-        { CAGE_TEMP0,  TEMP_CAGE0_NAME },
-        { CAGE_TEMP1,  TEMP_CAGE1_NAME }
+        { CAGE_TEMP0_SC,  TEMP_CAGE0_NAME },
+        { CAGE_TEMP1_SC,  TEMP_CAGE1_NAME }
     };
 
     if(NULL != snsrName)
@@ -270,7 +271,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
-	    .sesnorListTbl = SE98_TEMP0,
+	    .sesnorListTbl = SE98_TEMP0_SC,
 	    .sampleCount = 0x1,
 	    .monitorFunc = &Temperature_Read_Inlet,
 
@@ -282,7 +283,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
 	    .sampleCount = 0x1,
-	    .sesnorListTbl = SE98_TEMP1,
+	    .sesnorListTbl = SE98_TEMP1_SC,
 	    .monitorFunc = &Temperature_Read_Outlet,
 	},
 */
@@ -293,7 +294,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
 	    .sampleCount = 0x1,
-	    .sesnorListTbl = FAN_TEMP,
+	    .sesnorListTbl = FAN_TEMP_SC,
 	    .monitorFunc = &Temperature_Read_Board,
 	},
 	{
@@ -303,7 +304,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
 	    .sampleCount = 0x1,
-	    .sesnorListTbl = FPGA_TEMP,
+	    .sesnorListTbl = FPGA_TEMP_SC,
 	    .monitorFunc = &Temperature_Read_ACAP_Device_Sysmon,
 	},
 	{
@@ -313,7 +314,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .snsrUnitModifier = 0x0,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
 	    .sampleCount = 0x1,
-	    .sesnorListTbl = VCCINT_TEMP,
+	    .sesnorListTbl = VCCINT_TEMP_SC,
 	    .monitorFunc = &PMBUS_SC_Sensor_Read,
 	},
 	{
@@ -363,7 +364,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	    .snsrUnitModifier = -3,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
 	    .sampleCount = 0x1,
-	    .sesnorListTbl = VCCINT_I,
+	    .sesnorListTbl = VCCINT_I_SC,
 	    .monitorFunc = &PMBUS_SC_Vccint_Read,
 	},
 	{
@@ -1319,7 +1320,7 @@ u8 Asdm_Send_I2C_Sensors_SC(u8 *scPayload)
 	    /* We do not need send VCCINT_TEMP to SC,
  	       as we are receiving it from SC
 	    */
-	    if(sensorRecord[i].mspSensorId == VCCINT_TEMP)
+	    if(sensorRecord[i].mspSensorId == VCCINT_TEMP_SC)
 	    {
 		continue;
 	    }

--- a/vmr/src/vmc/vmc_sc_comms.c
+++ b/vmr/src/vmc/vmc_sc_comms.c
@@ -5,7 +5,8 @@
 #include "cl_mem.h"
 #include "vmc_sc_comms.h"
 #include "vmc_update_sc.h"
-
+#include "cl_uart_rtos.h"
+#include "vmc_api.h"
 
 EventGroupHandle_t xScUpdateEvent = NULL;
 
@@ -33,9 +34,9 @@ u8 scPayload[128] = {0};
 
 static u8 vmc_active_resp_len = MSP432_COMMS_MSG_GOOD_LEN;
 
-static volatile bool is_SC_active  = false ;
-volatile bool isPowerModeActive = false;
-volatile bool getSensorRespLen = false;
+static volatile bool is_SC_active  = false;
+static volatile bool isPowerModeActive = false;
+static volatile bool getSensorRespLen = false;
 
 u8 VMC_SC_Comms_Msg[] = {
        MSP432_COMMS_VOLT_SNSR_REQ,
@@ -140,13 +141,13 @@ void VMC_Update_Version_PowerMode(u16 length,u8 *payload)
 		switch(payload[i])
 		{
 		
-		case BMC_VERSION:
+		case BMC_VERSION_SC:
 			sc_vmc_data.scVersion[0] = payload[i+2];  // fw_version
 			sc_vmc_data.scVersion[1] = payload[i+3];  // fw_rev_major
 			sc_vmc_data.scVersion[2] = payload[i+4];  // fw_rev_minor
 			break;
 		
-		case TOTAL_POWER_AVAIL:
+		case TOTAL_POWER_AVAIL_SC:
 			sc_vmc_data.availpower = payload[i+2];
 			break;
 		}
@@ -161,7 +162,7 @@ void VMC_StoreSensor_Value(u8 id, u32 value)
 
 	if (xSemaphoreTake(vmc_sc_lock, portMAX_DELAY))
 	{
-		if(id == VCCINT_I) {
+		if(id == VCCINT_I_SC) {
 			sc_vmc_data.VCCINT_sensor_value = value;
 		} else {
 			sc_vmc_data.sensor_values[id] = value;

--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -1,18 +1,15 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
-* SPDX-License-Identifier: MIT
-*******************************************************************************/
-#include "xil_types.h"
-#include "FreeRTOS.h"
-#include "task.h"
+ * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *******************************************************************************/
 
+#ifndef SRC_VMC_VMC_SC_COMMS_H_
+#define SRC_VMC_VMC_SC_COMMS_H_
 
-#include "xsysmonpsv.h"
-#include "cl_uart_rtos.h"
-#include "vmc_api.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <stdbool.h>
 
-
-extern uart_rtos_handle_t uart_vmcsc_log;
 
 #define SOP_SIZE            (2)
 #define MESSAGE_ID_SIZE     (1)
@@ -26,91 +23,57 @@ extern uart_rtos_handle_t uart_vmcsc_log;
 #define ETX                 (0x03)
 #define ESCAPE_CHAR         (0x5C)
 
-// board info sizes
-#define BOARD_NAME_SIZE     17
-#define BOARD_REV_SIZE      9
-#define BOARD_SERIAL_SIZE   15
-#define MAC_ADDRESS_SIZE    18
-#define SAT_FW_REV_SIZE     9
+#define COMMS_PAYLOAD_START_INDEX    (5)
+#define RAW_PAYLOAD_LENTGH           (9)
 
-#define CMC_NUM_QSFP_CAGES  2
-#define CAGE_GPIO_INT_L     (1<<4)
-#define CAGE_GPIO_MODPRS_L  (1<<3)
-#define CAGE_GPIO_MODSEL_L  (1<<2)
-#define CAGE_GPIO_RESET_L   (1<<1)
-#define CAGE_GPIO_LPMODE    (1)
+#define MAX_VMC_SC_UART_BUF_SIZE		(255)
+#define MAX_VMC_SC_UART_COUNT_WITH_INTR		(60)
+#define MAX_VMC_SC_UART_COUNT_WITHOUT_INTR	(32)
 
+#define MSP432_COMMS_SUPPORTED_MSG		(0x0A)
+#define MSP432_COMMS_ALERT_RESP			(0x82)
+#define MSP432_COMMS_ADV_VERS_RESP		(0x83)
+#define MSP432_COMMS_BOARD_SNSR_RESP		(0x85)
+#define MSP432_COMMS_VOLT_SNSR_RESP		(0x86)
+#define MSP432_COMMS_POWER_SNSR_RESP		(0x87)
+#define MSP432_COMMS_TEMP_SNSR_RESP		(0x88)
+#define MSP432_COMMS_EN_DEMO_RESP		(0x89)
 
-#define COMMS_PAYLOAD_START_INDEX    5
-#define RAW_PAYLOAD_LENTGH           9
+#define MSP432_COMMS_MSG_GOOD			(0xFE)
+#define MSP432_COMMS_MSG_ERR			(0xFF)
 
-#define MAX_VMC_SC_UART_BUF_SIZE            255
-#define MAX_VMC_SC_UART_COUNT_WITH_INTR     60
-#define MAX_VMC_SC_UART_COUNT_WITHOUT_INTR  32
+#define MSP432_COMMS_MSG_GOOD_LEN		(0x0A)
+#define MSP432_COMMS_MSG_ERR_LEN		(0x0B)
 
+#define MSP432_COMMS_OEM_CMD_REQ		(0x6F)
+#define MSP432_COMMS_OEM_CMD_RESP		(0xEF)
+#define PAYLOAD_SIZE_OEM_ID_RESP		(0x04)
 
+#define MSP432_COMMS_NULL			(0x00)
+#define MSP432_COMMS_EN_BSL			(0x01)
+#define MSP432_COMMS_ALERT_REQ			(0x02)
+#define MSP432_COMMS_ADV_VERS			(0x03)
+#define MSP432_COMMS_SET_VERS			(0x04)
+#define MSP432_COMMS_BOARD_SNSR_REQ		(0x05)
+#define MSP432_COMMS_VOLT_SNSR_REQ		(0x06)
+#define MSP432_COMMS_POWER_SNSR_REQ		(0x07)
+#define MSP432_COMMS_TEMP_SNSR_REQ		(0x08)
+#define MSP432_COMMS_EN_DEMO_MENU		(0x09)
 
-#define MSP432_COMMS_SUPPORTED_MSG      (0x0A)
-#define MSP432_COMMS_ALERT_RESP         (0x82)
-#define MSP432_COMMS_ADV_VERS_RESP      (0x83)
-#define MSP432_COMMS_BOARD_SNSR_RESP    (0x85)
-#define MSP432_COMMS_VOLT_SNSR_RESP     (0x86)
-#define MSP432_COMMS_POWER_SNSR_RESP    (0x87)
-#define MSP432_COMMS_TEMP_SNSR_RESP     (0x88)
-#define MSP432_COMMS_EN_DEMO_RESP       (0x89)
+#define MSP432_COMMS_NO_FLAG			(0x00)
+#define MSP432_COMMS_VMC_VERSION		(0x50)
+#define MSP432_COMMS_VMC_ACTIVE_REQ 		(0xF0)
 
-#define MSP432_COMMS_MSG_GOOD           (0xFE)
-#define MSP432_COMMS_MSG_ERR            (0xFF)
-
-#define MSP432_COMMS_MSG_GOOD_LEN       (0x0A)
-#define MSP432_COMMS_MSG_ERR_LEN        (0x0B)
-
-#define MSP432_COMMS_OEM_CMD_REQ        (0x6F)
-#define MSP432_COMMS_OEM_CMD_RESP       (0xEF)
-#define PAYLOAD_SIZE_OEM_ID_RESP        (0x04)
-
-#define MSP432_COMMS_NULL               (0x00)
-#define MSP432_COMMS_EN_BSL             (0x01)
-#define MSP432_COMMS_ALERT_REQ          (0x02)
-#define MSP432_COMMS_ADV_VERS           (0x03)
-#define MSP432_COMMS_SET_VERS           (0x04)
-#define MSP432_COMMS_BOARD_SNSR_REQ     (0x05)
-#define MSP432_COMMS_VOLT_SNSR_REQ      (0x06)
-#define MSP432_COMMS_POWER_SNSR_REQ     (0x07)
-#define MSP432_COMMS_TEMP_SNSR_REQ      (0x08)
-#define MSP432_COMMS_EN_DEMO_MENU       (0x09)
-
-#define MSP432_COMMS_NO_FLAG             (0x00)
-#define MSP432_COMMS_VMC_VERSION             (0x50)
-#define MSP432_COMMS_VMC_ACTIVE_REQ 	(0xF0)
-
-#define MSP432_COMMS_VMC_VERSION_POWERMODE_REQ (0xF1)
+#define MSP432_COMMS_VMC_VERSION_POWERMODE_REQ 	(0xF1)
 #define MSP432_COMMS_VMC_VERSION_POWERMODE_RESP (0xF2)
 
-#define MSP432_COMMS_VMC_SEND_I2C_SNSR_REQ (0xF3)
-#define MSP432_COMMS_VMC_SEND_I2C_SNSR_RESP (0xF4)
+#define MSP432_COMMS_VMC_SEND_I2C_SNSR_REQ 	(0xF3)
+#define MSP432_COMMS_VMC_SEND_I2C_SNSR_RESP 	(0xF4)
 
-#define MSP432_COMMS_VMC_GET_RESP_SIZE_REQ (0xF5)
-#define MSP432_COMMS_VMC_GET_RESP_SIZE_RESP (0xF6)
-
-
-typedef enum return_error_codes {
-    FIELD_PARSE_SUCCESSFUL,                 /* The current field was parsed successfully */
-    MSP432_COMMS_CHKSUM_ERR,                /* did not match for message */
-    MSP432_COMMS_EOP_ERR,                   /* EOP was detected too early (i.e. dropped byte during communication) */
-    MSP432_COMMS_SOP_ERR,                   /* SOP was detected before EOP of last message. (i.e. dropped byte during communication) */
-    MSP432_COMMS_ESC_SEQ_ERR,               /* Undefined escape character sequence */
-    MSP432_COMMS_BAD_MSG_ID,                /* Unrecognized message id */
-    MSP432_COMMS_BAD_VERSION,               /* Unable to configure to specified version */
-    MSP432_COMMS_RX_BUF_OVERFLOW,           /* XMC's Receive buffer overflowed*/
-    MSP432_COMMS_BAD_SNSR_ID,               /* Unrecognized sensor (Byte 2 should be the sensor ID) */
-    MSP432_COMMS_NS_MSG_ID,                 /* Message ID not supported */
-    MSP432_COMMS_SC_FUN_ERR,                /* Indicates SC functionality Error */
-    MSP432_COMMS_FAIL_TO_EN_BSL             /* Unable to Enter into BSL mode*/
-}return_error_codes;
+#define MSP432_COMMS_VMC_GET_RESP_SIZE_REQ 	(0xF5)
+#define MSP432_COMMS_VMC_GET_RESP_SIZE_RESP 	(0xF6)
 
 typedef enum Comms_field_parser {
-
 	SOP_ESCAPE_CHAR,
 	SOP_ETX,
 	Rsp_MessageID,
@@ -118,176 +81,63 @@ typedef enum Comms_field_parser {
 	PayloadLength,
 	EOP_ESCAPE_CHAR,
 	EOP_ETX
-
 }Comms_field_parser;
 
-
 typedef struct vmc_sc_uart_cmd {
-    uint8_t SOP[2];
-    uint8_t MessageID;
-    uint8_t Flags;
-    uint8_t PayloadLength;
-    uint8_t Payload[255];
-    uint8_t Checksum[2];
-    uint8_t EOP[2];
-
+	uint8_t SOP[2];
+	uint8_t MessageID;
+	uint8_t Flags;
+	uint8_t PayloadLength;
+	uint8_t Payload[255];
+	uint8_t Checksum[2];
+	uint8_t EOP[2];
 }vmc_sc_uart_cmd;
 
-typedef enum // satellite controller sensor and info ids
-{
-    SNSR_ID_12V_PEX = 0x0,
-    SNSR_ID_3V3_PEX,
-    SNSR_ID_3V3_AUX,
-    SNSR_ID_12V_AUX,
-    SNSR_ID_DDR4_VPP_BTM,
-    SNSR_ID_SYS_5V5,
-    SNSR_ID_VCC1V2_TOP,
-    SNSR_ID_VCC1V8,
-    SNSR_ID_VCC0V85,
-    SNSR_ID_DDR4_VPP_TOP,
-    SNSR_ID_MGT0V9AVCC,
-    SNSR_ID_12V_SW,
-    SNSR_ID_MGTAVTT,
-    SNSR_ID_VCC1V2_BTM,
-    SNSR_ID_12VPEX_I_IN,
-    SNSR_ID_12V_AUX_I_IN,
-    SNSR_ID_VCCINT,
-    SNSR_ID_VCCINT_I,
-    SNSR_ID_FPGA_TEMP,
-    SNSR_ID_FAN_TEMP,
-    SNSR_ID_DIMM_TEMP0,
-    SNSR_ID_DIMM_TEMP1,
-    SNSR_ID_DIMM_TEMP2,
-    SNSR_ID_DIMM_TEMP3,
-    SNSR_ID_SE98_TEMP0,
-    SNSR_ID_SE98_TEMP1,
-    SNSR_ID_SE98_TEMP2,
-    SNSR_ID_FAN_SPEED,
-    SNSR_ID_CAGE_TEMP0,
-    SNSR_ID_CAGE_TEMP1,
-    SNSR_ID_CAGE_TEMP2,
-    SNSR_ID_CAGE_TEMP3,
-    SNSR_ID_BOARD_SN = 0x21,
-    SNSR_ID_MAC_ADDRESS0,
-    SNSR_ID_MAC_ADDRESS1,
-    SNSR_ID_MAC_ADDRESS2,
-    SNSR_ID_MAC_ADDRESS3,
-    SNSR_ID_BOARD_REV,
-    SNSR_ID_BOARD_NAME,
-    SNSR_ID_SAT_VERSION,
-    SNSR_ID_TOTAL_POWER_AVAIL,
-    SNSR_ID_FAN_PRESENCE,
-    SNSR_ID_CONFIG_MODE,
-    SNSR_ID_HBM_TEMP1 = 0x30,
-    SNSR_ID_VCC_3V3,
-    SNSR_ID_3V3PEX_I_IN,
-    SNSR_ID_VCC0V85_I,
-    SNSR_ID_HBM_1V2,
-    SNSR_ID_VPP2V5,
-    SNSR_ID_VCCINT_BRAM,
-    SNSR_ID_HBM_TEMP2 = 0x37,
-    CMC_MAX_NUM_SNSRS,
-}Sensor_id;
-
-/* List sensor ids used for communicating between MB and MSP */
+/* List of sensor id's used for communicating between VMC and MSP */
 typedef enum
 {
-    PEX_12V = 0,
-    PEX_3V3,
-    AUX_3V3,
-    AUX_12V,
-    DDR4_VPP_BTM,
-    SYS_5V5,
-    VCC1V2_TOP,
-    VCC1V8,
-    VCC0V85,
-    DDR4_VPP_TOP,
-    MGT0V9AVCC,
-    SW_12V,
-    MGTAVTT,
-    VCC1V2_BTM,
-    PEX_12V_I_IN,
-    AUX_12V_I_IN,
-	VCCINT_SC, //Dummy sensor in enum just to keep the ordering.
-    VCCINT_I,
-    FPGA_TEMP,
-    FAN_TEMP,
-    DIMM_TEMP0,
-    DIMM_TEMP1,
-    DIMM_TEMP2,
-    DIMM_TEMP3,
-    SE98_TEMP0,
-    SE98_TEMP1,
-    SE98_TEMP2,
-    FAN_SPEED,
-    CAGE_TEMP0,
-    CAGE_TEMP1,
-    CAGE_TEMP2,
-    CAGE_TEMP3,
-    RESERVED5,
-    BOARD_SN,
-    MAC_ADDRESS0,
-    MAC_ADDRESS1,
-    MAC_ADDRESS2,
-    MAC_ADDRESS3,
-    BOARD_REV,
-    BOARD_NAME,
-    BMC_VERSION,
-    TOTAL_POWER_AVAIL,
-    FAN_PRESENCE,
-    CONFIGURATION_MODE,
-    HBM_TEMP1 = 0x30,
-    VCC_3V3,
-    PEX3V3_I_IN,
-    VCC0V85_I,
-    HBM_1V2,
-    VPP2V5,
-    VCCINT_BRAM,
-    HBM_TEMP2,
-    AUX1_12V,
-    VCCINT_TEMP = 0x39,
-    PEX_12V_POWER,
-    PEX_3V3_POWER,
-    AUX_3V3_I,
-    VCC1V2_I = 0x3F,
-    V12_IN_I,
-    V12_IN_AUX0_I,
-    V12_IN_AUX1_I,
-    VCCAUX_SC,
-    VCCAUX_PMC,
-    VCCRAM,
-    POWER_GOOD = 0x46,
-    NEW_MAC_SCHEME_ID = 0x4B,
-    HBM_T_1V2 = 0x4C,
-    HBM_B_1V2,
-    VPP_T_2V5,
-    VPP_B_2V5,
-    SENSOR_ID_MAX
+	PEX_12V_SC = 0,
+	PEX_3V3_SC,
+	AUX_3V3_SC,
+	AUX_12V_SC,
+	PEX_12V_I_IN_SC = 0x0E,
+	VCCINT_SC = 0x10,
+	VCCINT_I_SC,
+	FPGA_TEMP_SC,
+	FAN_TEMP_SC,
+	SE98_TEMP0_SC = 0x18,
+	SE98_TEMP1_SC,
+	CAGE_TEMP0_SC = 0x1C,
+	CAGE_TEMP1_SC,
+	BOARD_SN_SC = 0x21,
+	MAC_ADDRESS0_SC,
+	MAC_ADDRESS1_SC,
+	MAC_ADDRESS2_SC,
+	MAC_ADDRESS3_SC,
+	BOARD_REV_SC,
+	BOARD_NAME_SC,
+	BMC_VERSION_SC,
+	TOTAL_POWER_AVAIL_SC,
+	FAN_PRESENCE_SC,
+	AUX1_12V_SC = 0x38,
+	VCCINT_TEMP_SC,
+	V12_IN_AUX0_I_SC = 0x41,
+	V12_IN_AUX1_I_SC,
+	SENSOR_ID_MAX_SC
 }sensor_id_list;
 
-typedef struct SC_VMC_Data{
-    bool boardInfoStatus;
-    u8   voltsensorlength;
-    u8   powersensorlength;
-    u8   availpower;
-    u8   configmode;
-    u8   scVersion[4];
-    u32  VCCINT_sensor_value;
-    u16  sensor_values[SENSOR_ID_MAX];
+typedef struct SC_VMC_Data {
+	bool boardInfoStatus;
+	u8 voltsensorlength;
+	u8 powersensorlength;
+	u8 availpower;
+	u8 configmode;
+	u8 scVersion[4];
+	u32 VCCINT_sensor_value;
+	u16 sensor_values[SENSOR_ID_MAX_SC];
 }SC_VMC_Data;
 
 
-
-void Update_MSGgood_Data(u8 PayloadLength , u8 * Payload);
-void Update_CommsVersion_Response(u8 PayloadLength , u8 * Payload);
-u16 vmcU8ToU16(u8 *payload);
-uint64_t vmcU8ToU64(uint8_t * payload);
-void Update_OEM_Data(u8 PayloadLength , u8 * Payload);
-void VMC_StoreSensor_Value(u8 id, u32 value);
-void VMC_Update_Sensors(u16 length,u8 *payload);
-void Update_SNSR_Data(u8 PayloadLength , u8 * payload);
-bool Parse_SCData(u8 *Payload);
-bool VMC_send_packet(u8 Message_id , u8 Flags,u8 Payloadlength, u8 *Payload);
 bool vmc_get_sc_status();
 void vmc_set_sc_status(bool value);
 bool vmc_get_power_mode_status();
@@ -295,3 +145,4 @@ void vmc_set_power_mode_status(bool value);
 bool vmc_get_snsr_resp_status();
 void vmc_set_snsr_resp_status(bool value);
 
+#endif /* SRC_VMC_VMC_SC_COMMS_H_ */

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -369,9 +369,9 @@ s8 Power_Monitor(snsrRead_t *snsrData)
     if (xSemaphoreTake(vmc_sc_lock, portMAX_DELAY))
     {
     	power_mode =  sc_vmc_data.availpower;
-    	pexPower = ((sc_vmc_data.sensor_values[PEX_12V]/1000.0) * (sc_vmc_data.sensor_values[PEX_12V_I_IN])/1000.0);
-    	aux0Power = ((sc_vmc_data.sensor_values[AUX_12V]/1000.0) * (sc_vmc_data.sensor_values[V12_IN_AUX0_I])/1000.0); //2x4 AUX
-    	aux1Power = ((sc_vmc_data.sensor_values[AUX1_12V]/1000.0) * (sc_vmc_data.sensor_values[V12_IN_AUX1_I])/1000.0); //2x3 AUX
+    	pexPower = ((sc_vmc_data.sensor_values[PEX_12V_SC]/1000.0) * (sc_vmc_data.sensor_values[PEX_12V_I_IN_SC])/1000.0);
+    	aux0Power = ((sc_vmc_data.sensor_values[AUX_12V_SC]/1000.0) * (sc_vmc_data.sensor_values[V12_IN_AUX0_I_SC])/1000.0); //2x4 AUX
+    	aux1Power = ((sc_vmc_data.sensor_values[AUX1_12V_SC]/1000.0) * (sc_vmc_data.sensor_values[V12_IN_AUX1_I_SC])/1000.0); //2x3 AUX
     	totalPower = (pexPower + aux0Power +aux1Power);
     	xSemaphoreGive(vmc_sc_lock);
     }
@@ -567,7 +567,7 @@ void qsfp_monitor(void)
 void Monitor_Thresholds()
 {
 	static bool is_vccint_temp_critical_threshold_reached = false;
-	u16 sensorReading = sc_vmc_data.sensor_values[VCCINT_TEMP];
+	u16 sensorReading = sc_vmc_data.sensor_values[VCCINT_TEMP_SC];
 
 	if (sensorReading >= TEMP_VCCINT_CRITICAL_THRESHOLD)
 	{


### PR DESCRIPTION
	- Cleaned up a few unused enums which were causing conflict with SYSMON supplies.

Signed-off-by: Sibasish Rout <sibasish.rout@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Cleaned up a few unused enums which were causing conflict with SYSMON supplies.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1128393
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
```
xbutil examine --report electrical thermal -d 0000:3b:00.1

-------------------------------------------------------
1/1 [0000:3b:00.1] : xilinx_vck5000_gen4x8_xdma_base_2
-------------------------------------------------------
Electrical
  Max Power              : NA Watts
  Power                  : 23 Watts
  Power Warning          : NA

  Power Rails            : Voltage   Current
  12v_pex                : 12.187 V,  0.875 A
  3v3_pex                :  3.291 V
  3v3_aux                :  3.296 V
  12v_aux_0              : 12.202 V,  0.824 A
  12v_aux_1              : 12.179 V,  0.298 A
  vccint                 :  0.801 V, 69.600 A

Thermals
  Temperature            : Celcius
  PCB                    :     25 C
  device                 :     35 C
  vccint                 :     36 C
  cage_temp_0            :     28 C
  cage_temp_1            :     30 C
```
#### Documentation impact (if any)
NA