### PR TITLE
Add multiplatform support

### DIFF
--- a/vmr/src/include/cl_main.h
+++ b/vmr/src/include/cl_main.h
@@ -13,7 +13,7 @@ int cl_xgq_program_init(void);
 int cl_xgq_opcode_init(void);
 int cl_vmc_sensor_init(void);
 int cl_vmc_sc_comms_init(void);
-int cl_uart_demo(void);
+int cl_uart_demo_init(void);
 
 void cl_xgq_receive_func(void *task_args);
 void cl_xgq_program_func(void *task_args);

--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -21,6 +21,8 @@
 #include "cl_main.h"
 #include "cl_io.h"
 
+#include "vmc_asdm.h"
+
 #define	VMC_STRING	"VMC"
 
 #ifdef VMC_DEBUG
@@ -87,6 +89,46 @@ typedef struct Versal_BoardInfo
     unsigned char DIMM_size[5];
     unsigned char Num_MAC_IDS;
 } Versal_BoardInfo;
+
+#define 	MAX_PLATFORM_NAME_LEN (20u)
+#define 	MAX_FUNCTION_NAME_LEN (20u)
+
+typedef enum{
+	eVCK5000 = 0, /* VCK5000 or V350, so 2 platforms in one enum*/
+	eV70 = 2,
+	eMax_Platforms,
+} ePlatformType;
+
+typedef struct __attribute__((packed)) {
+	ePlatformType 	product_type_id;
+	char		product_type_name[MAX_PLATFORM_NAME_LEN];
+} Platform_t;
+
+typedef enum{
+	eTemperature_Sensor_Inlet = 0,
+	eTemperature_Sensor_Outlet,
+	eTemperature_Sensor_Board,
+	eTemperature_Sensor_QSFP,
+	//eFAN_RPM_READ,
+	eMax_Sensor_Functions,
+} eSensor_Functions;
+
+#if 0
+typedef struct __attribute__((packed)) {
+	eSensor_Functions	sensor_type;
+	char	product_type_name[MAX_FUNCTION_NAME_LEN];
+	//s8		(*sensor_handler)(snsrRead_t *snsrData);
+	sensorMonitorFunc	sensor_handler;
+}Sensor_Handler_t;
+#endif
+
+typedef struct __attribute__((packed)) {
+	ePlatformType 	product_type_id;
+	eSensor_Functions	sensor_type;
+	//s8		(*sensor_handler)(snsrRead_t *snsrData);
+	sensorMonitorFunc	sensor_handler;
+}Platform_Sensor_Handler_t;
+
 
 /*****************************************************************************/
 /**
@@ -195,5 +237,16 @@ void EepromDump(void);
 **
 ******************************************************************************/
 u8 Versal_EEPROM_ReadBoardInfo(void);
+
+
+s8 Vck5000_Temperature_Read_Inlet(snsrRead_t *snsrData);
+s8 Vck5000_Temperature_Read_Outlet(snsrRead_t *snsrData);
+s8 Vck5000_Temperature_Read_Board(snsrRead_t *snsrData);
+s8 Vck5000_Temperature_Read_QSFP(snsrRead_t *snsrData);
+
+extern sensorMonitorFunc Temperature_Read_Inlet_Ptr;
+extern sensorMonitorFunc Temperature_Read_Outlet_Ptr;
+extern sensorMonitorFunc Temperature_Read_Board_Ptr;
+extern sensorMonitorFunc Temperature_Read_QSFP_Ptr;
 
 #endif /* INC_VMC_API_H_ */

--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -61,16 +61,16 @@ extern SC_VMC_Data sc_vmc_data;
 extern u8 fpt_sc_version[3];
 
 void Asdm_Update_Active_MSP_sensor();
-extern s8 Temperature_Read_Inlet(snsrRead_t *snsrData);
-extern s8 Temperature_Read_Outlet(snsrRead_t *snsrData);
-extern s8 Temperature_Read_Board(snsrRead_t *snsrData);
-extern s8 Temperature_Read_ACAP_Device_Sysmon(snsrRead_t *snsrData);
-extern s8 Fan_RPM_Read(snsrRead_t *snsrData);
-extern s8 Temperature_Read_QSFP(snsrRead_t *snsrData);
-extern s8 PMBUS_SC_Sensor_Read(snsrRead_t *snsrData);
-extern s8 Power_Monitor(snsrRead_t *snsrData);
-extern s8 PMBUS_SC_Vccint_Read(snsrRead_t *snsrData);
-extern s8 VCCINT_Read_ACAP_Device_Sysmon(snsrRead_t *snsrData);
+s8 Temperature_Read_Inlet(snsrRead_t *snsrData);
+s8 Temperature_Read_Outlet(snsrRead_t *snsrData);
+s8 Temperature_Read_Board(snsrRead_t *snsrData);
+s8 Temperature_Read_QSFP(snsrRead_t *snsrData);
+s8 Temperature_Read_ACAP_Device_Sysmon(snsrRead_t *snsrData);
+s8 Fan_RPM_Read(snsrRead_t *snsrData);
+s8 PMBUS_SC_Sensor_Read(snsrRead_t *snsrData);
+s8 Power_Monitor(snsrRead_t *snsrData);
+s8 PMBUS_SC_Vccint_Read(snsrRead_t *snsrData);
+s8 VCCINT_Read_ACAP_Device_Sysmon(snsrRead_t *snsrData);
 
 Asdm_Sensor_Thresholds_t thresholds_limit_tbl[]= {
     /*  Name           LW   LC   LF    UW   UC  UF  */

--- a/vmr/src/vmc/vmc_asdm.h
+++ b/vmr/src/vmc/vmc_asdm.h
@@ -2,6 +2,9 @@
 * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
+#ifndef INC_VMC_ASDM_H_
+#define INC_VMC_ASDM_H_
+
 #include "xil_types.h"
 
 typedef enum VMC_Sensor_State_e
@@ -197,4 +200,6 @@ typedef enum Sensor_Status_Enum_e
 s8 Init_Asdm();
 void Monitor_Sensors(void);
 s8 Asdm_Process_Sensor_Request(u8 *req, u8 *resp, u16 *respSize);
+
+#endif
 

--- a/vmr/src/vmc/vmc_demo.c
+++ b/vmr/src/vmc/vmc_demo.c
@@ -124,7 +124,7 @@ static void App_SetLogLevel(void)
 /*
  *  ======== Menu Task ========
  */
-void cl_uart_demo_func(void *arg0)
+void cl_uart_demo_func(void *task_args)
 {
     u8 TestIndex = 0;
     u8 MenuLevel = 0;
@@ -250,7 +250,7 @@ void cl_uart_demo_func(void *arg0)
     return;
 }
 
-int cl_uart_demo(void)
+int cl_uart_demo_init(void)
 {
 	return 0;
 }

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -28,6 +28,26 @@ uart_rtos_handle_t uart_vmcsc_log;
 uart_rtos_handle_t uart_log;
 
 static bool vmc_is_ready = false;
+static ePlatformType current_platform = eV70;
+
+Platform_t platform_names[eMax_Platforms]=
+{
+	{eVCK5000,"V350\0"},
+	{eVCK5000,"VCK5000\0"},
+	{eV70,"V70\0"},
+};
+
+Platform_Sensor_Handler_t platform_sensor_handlers[]=
+{
+	{eVCK5000,eTemperature_Sensor_Inlet,Vck5000_Temperature_Read_Inlet},
+	{eVCK5000,eTemperature_Sensor_Outlet,Vck5000_Temperature_Read_Outlet},
+	{eVCK5000,eTemperature_Sensor_Board,Vck5000_Temperature_Read_Board},
+	{eVCK5000,eTemperature_Sensor_QSFP,Vck5000_Temperature_Read_QSFP},
+};
+
+extern Versal_BoardInfo board_info;
+
+static u8 Vmc_ConfigurePlatform(const char * product_name);
 
 int cl_vmc_is_ready()
 {
@@ -39,15 +59,7 @@ int cl_vmc_is_ready()
 
 int cl_vmc_init()
 {
-	s8 Status = 0;
-
-	cl_I2CInit();
-
-	Status = UART_VMC_SC_Enable(&uart_vmcsc_log);
-	if (Status != XST_SUCCESS) {
-		VMR_ERR("UART VMC to SC init failed");
-		return -EINVAL;
-	}
+	s8 status = 0;
 
 #ifdef VMC_DEBUG
 	/* Enable FreeRTOS Debug UART */
@@ -57,8 +69,28 @@ int cl_vmc_init()
 	/* Demo Menu is already enabled by cl_main task handler */
 #endif
 
+	cl_I2CInit();
+
 	/* Read the EEPROM */
-	Versal_EEPROM_ReadBoardInfo();
+	status = Versal_EEPROM_ReadBoardInfo();
+	if(XST_FAILURE == status){
+		vmc_is_ready = false;
+		VMR_ERR("EEPROM Read Failed.");
+		return -EINVAL;
+	}
+
+	status = Vmc_ConfigurePlatform((const char *)&board_info.product_name[0]);
+	if(XST_FAILURE == status){
+		vmc_is_ready = false;
+		VMR_ERR("Platform is Unknown.");
+		return -EINVAL;
+	}
+
+	status = UART_VMC_SC_Enable(&uart_vmcsc_log);
+	if (status != XST_SUCCESS) {
+		VMR_ERR("UART VMC to SC init Failed");
+		return -EINVAL;
+	}
 
 	/* Retry till fan controller is programmed */
 	while (max6639_init(1, 0x2E));  // only for vck5000
@@ -77,6 +109,71 @@ int cl_vmc_init()
 	}
 
 	vmc_is_ready = true;
-	VMC_LOG("Done. set vmc is ready.");
+	VMR_LOG("Done. set vmc is ready.");
 	return 0;
+}
+
+
+sensorMonitorFunc Vmc_Find_Sensor_Handler(eSensor_Functions sensor_type)
+{
+	u16 j = 0;
+	u16 platform_sensors_len = ARRAY_SIZE(platform_sensor_handlers);
+
+	for(j = 0; j < platform_sensors_len; j++){
+		if((current_platform == platform_sensor_handlers[j].product_type_id)
+				&& sensor_type == platform_sensor_handlers[j].sensor_type){
+
+			return platform_sensor_handlers[j].sensor_handler;
+		}
+	}
+
+	return NULL;
+}
+
+static u8 Vmc_ConfigurePlatform(const char * product_name)
+{
+	u8 i = 0;
+	u8 status = XST_FAILURE;
+	if(product_name == NULL){
+		VMR_ERR("Platform type is unknown!");
+		return status;
+	}
+	else
+	{
+		for(i = 0; i < eMax_Platforms; i++){
+			if(strstr(product_name,&platform_names[i].product_type_name[0]) != NULL){
+				current_platform = platform_names[i].product_type_id;
+				status = XST_SUCCESS;
+				VMR_LOG("Current Platform is %s",&platform_names[i].product_type_name[0]);
+				break;
+			}
+		}
+	}
+
+	if(XST_SUCCESS != status)
+		return status;
+
+	for(i = 0; i < eMax_Sensor_Functions; i++){
+		switch (i){
+			case eTemperature_Sensor_Inlet:
+				Temperature_Read_Inlet_Ptr = Vmc_Find_Sensor_Handler(i);
+				break;
+
+			case eTemperature_Sensor_Outlet:
+				Temperature_Read_Outlet_Ptr = Vmc_Find_Sensor_Handler(i);
+				break;
+
+			case eTemperature_Sensor_Board:
+				Temperature_Read_Board_Ptr = Vmc_Find_Sensor_Handler(i);
+				break;
+
+			case eTemperature_Sensor_QSFP:
+				Temperature_Read_QSFP_Ptr = Vmc_Find_Sensor_Handler(i);
+				break;
+
+		}
+	}
+
+
+	return status;
 }

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -33,6 +33,11 @@ static int vmc_sysmon_is_ready = 0;
 static XSysMonPsv InstancePtr;
 static XScuGic IntcInst;
 
+sensorMonitorFunc Temperature_Read_Inlet_Ptr;
+sensorMonitorFunc Temperature_Read_Outlet_Ptr;
+sensorMonitorFunc Temperature_Read_Board_Ptr;
+sensorMonitorFunc Temperature_Read_QSFP_Ptr;
+
 extern SemaphoreHandle_t vmc_sc_lock;
 
 extern SC_VMC_Data sc_vmc_data;
@@ -84,7 +89,7 @@ void ucs_clock_shutdown()
    return;
 }
 
-s8 Temperature_Read_Inlet(snsrRead_t *snsrData)
+s8 Vck5000_Temperature_Read_Inlet(snsrRead_t *snsrData)
 {
 	s8 status = XST_FAILURE;
 	s16 tempValue = 0;
@@ -105,7 +110,7 @@ s8 Temperature_Read_Inlet(snsrRead_t *snsrData)
 	return status;
 }
 
-s8 Temperature_Read_Outlet(snsrRead_t *snsrData)
+s8 Vck5000_Temperature_Read_Outlet(snsrRead_t *snsrData)
 {
 	s8 status = XST_FAILURE;
 	s16 tempValue = 0;
@@ -126,7 +131,7 @@ s8 Temperature_Read_Outlet(snsrRead_t *snsrData)
 	return status;
 }
 
-s8 Temperature_Read_Board(snsrRead_t *snsrData)
+s8 Vck5000_Temperature_Read_Board(snsrRead_t *snsrData)
 {
 	s8 status = XST_FAILURE;
 	float TempReading = 0;
@@ -241,7 +246,7 @@ s8 Fan_RPM_Read(snsrRead_t *snsrData)
 
 	return status;
 }
-s8 Temperature_Read_QSFP(snsrRead_t *snsrData)
+s8 Vck5000_Temperature_Read_QSFP(snsrRead_t *snsrData)
 {
 	u8 status = XST_FAILURE;
 	float TempReading = 0.0;
@@ -634,6 +639,28 @@ done:
 	VMC_DBG("msg cid%d, ret %d", msg->hdr.cid, ret);
 	return ret;
 }
+
+
+s8 Temperature_Read_Inlet(snsrRead_t *snsrData)
+{
+	return (*Temperature_Read_Inlet_Ptr)(snsrData);
+}
+
+s8 Temperature_Read_Outlet(snsrRead_t *snsrData)
+{
+	return (*Temperature_Read_Outlet_Ptr)(snsrData);
+}
+
+s8 Temperature_Read_Board(snsrRead_t *snsrData)
+{
+	return (*Temperature_Read_Board_Ptr)(snsrData);
+}
+
+s8 Temperature_Read_QSFP(snsrRead_t *snsrData)
+{
+	return (*Temperature_Read_QSFP_Ptr)(snsrData);
+}
+
 
 void cl_vmc_monitor_sensors()
 {


### PR DESCRIPTION
-Multiplatform implementation skeleton is added
-Fixed multiple bugs from previous PRs

Signed-off-by: Shahab Alilou <shahaba@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added multi-platform support which includes support for V70.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR-142 and another one

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed the function name bug related to PR-142 and added header guard for vmc_asdm.h

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary

Sensors reading was tested:

------------------------------------------------------------------
------------------          ASDM Sensor Data    ------------------
------------------------------------------------------------------
|   Sensor Name    |   Value     | Status |    Max    |   Average |

Record Type : 0xc0
----------------------------------------------------------------
 Product Name           VCK5000-PP      Ok      NA      NA
 Serial Num             XFL1MA4MLLGE    Ok      NA      NA
 Part Num               05025-04        Ok      NA      NA
 Revision               A       Ok      NA      NA
 MFG Date               9763cd0 Ok      NA      NA
 UUID           eb87a7262e2f45b4927223af5f5a89380       Ok      NA      NA
 MAC 0          0a35cf63a0      Ok      NA      NA
 MAC 1          0a35cf63b0      Ok      NA      NA
 fpga_fan_1             A       Ok      NA      NA
 Active SC Ver          44200   Ok      NA      NA
 Target SC Ver          000     Ok      NA      NA
 OEM ID         da10000 Ok      NA      NA

Record Type : 0xc1
----------------------------------------------------------------
 PCB            42              Ok      42      42
 device         60              Ok      60      60
 vccint         52              Ok      52      50
 cage_temp_0            0               Error   0       0
 cage_temp_1            0               Error   0       0

Record Type : 0xc2
----------------------------------------------------------------
 12v_pex                12323           Ok      12326   12275
 3v3_pex                3310            Ok      3314    3295
 3v3_aux                3418            Ok      3419    3407
 12v_aux_0              12271           Ok      12274   12221
 12v_aux_1              12293           Ok      12297   12246
 vccint         799             Ok      801     799

Record Type : 0xc3
----------------------------------------------------------------
 12v_pex                793             Ok      799     793
 12v_aux_0              515             Ok      524     517
 12v_aux_1              318             Ok      320     317
 vccint         76800           Ok      81600   76718

Record Type : 0xc4
----------------------------------------------------------------
 Total Power            20              Ok      20      7


SE98A_0 temperature                     : 27
SE98A_1 temperature                     : 26
local temperature(max6639)              : 25.750000
remote temp or fpga temp(max6639)       : 38.750000
 Fan RPM (max6639)                      : 1882
 Maximum SYSMON temp                    : 34.601562
 QSFP_0 temperature                     : 0.000000
 QSFP_1 temperature                     : 0.000000

#### Documentation impact (if any)
N/A