### PR TITLE
VITIS-5847 Resilient VMR - Easy of Use SCFW program

### DIFF
--- a/vmr/src/common/cl_main.c
+++ b/vmr/src/common/cl_main.c
@@ -109,7 +109,8 @@ static TaskHandle_t cl_uart_demo_handle = NULL;
 
 static QueueHandle_t cl_xgq_program_queue = NULL;
 static QueueHandle_t cl_xgq_opcode_queue = NULL;
-static QueueHandle_t cl_vmc_sc_queue = NULL;
+static QueueHandle_t cl_vmc_sc_req_queue = NULL;
+static QueueHandle_t cl_vmc_sc_resp_queue = NULL;
 
 extern void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName)
 {
@@ -151,7 +152,8 @@ struct cl_queue_handle {
 } queue_handles[] = {
 	{CL_QUEUE_PROGRAM, "XGQ Program", &cl_xgq_program_queue},
 	{CL_QUEUE_OPCODE, "XGQ Opcode", &cl_xgq_opcode_queue},
-	{CL_QUEUE_SC, "SCFW", &cl_vmc_sc_queue},
+	{CL_QUEUE_SCFW_REQ, "SCFW Request", &cl_vmc_sc_req_queue},
+	{CL_QUEUE_SCFW_RESP, "SCFW Respond", &cl_vmc_sc_resp_queue},
 };
 
 /*

--- a/vmr/src/common/cl_vmc_sc_comms.c
+++ b/vmr/src/common/cl_vmc_sc_comms.c
@@ -49,8 +49,12 @@ void cl_vmc_sc_comms_func(void *task_args)
 	cl_msg_t msg;
 
 	while (1) {
-		if (cl_recv_from_queue_nowait(&msg, CL_QUEUE_SC) == 0) {
+		if (cl_recv_from_queue_nowait(&msg, CL_QUEUE_SCFW_REQ) == 0) {
 			process_scfw_msg(&msg);
+			/* set correct rcode based on scfw program */
+			cl_msg_set_rcode(&msg, 0);
+			/* send msg back via SCFW Response Queue */
+			(void) cl_send_to_queue(&msg, CL_QUEUE_SCFW_RESP);
 		}
 
 		/* every 1000ms we update sensor from vmc_sc_comms */

--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -74,7 +74,6 @@ static struct xgq_cmd_cl_map xgq_cmd_sensor_map[] = {
 	{XGQ_CMD_SENSOR_SID_ALL, CL_SENSOR_ALL},
 };
 
-
 int cl_msg_handle_complete(cl_msg_t *msg)
 {
 	struct xgq_com_queue_entry cq_cmd = {

--- a/vmr/src/include/cl_main.h
+++ b/vmr/src/include/cl_main.h
@@ -26,7 +26,8 @@ struct cl_msg;
 enum cl_queue_id {
 	CL_QUEUE_PROGRAM = 0,
 	CL_QUEUE_OPCODE,
-	CL_QUEUE_SC,
+	CL_QUEUE_SCFW_REQ,
+	CL_QUEUE_SCFW_RESP,
 };
 int cl_send_to_queue(struct cl_msg *msg, enum cl_queue_id qid);
 int cl_recv_from_queue(struct cl_msg *msg, enum cl_queue_id qid);

--- a/vmr/src/include/cl_msg.h
+++ b/vmr/src/include/cl_msg.h
@@ -149,18 +149,17 @@ typedef struct cl_msg {
 	};
 } cl_msg_t;
 
-typedef int (*process_msg_cb)(cl_msg_t *msg, void *arg);
-
-typedef struct msg_handle {
-	cl_msg_type_t 	type;
-	process_msg_cb 	msg_cb;
-	void 		*arg;
-	const char	*name;
-} msg_handle_t;
-
-int cl_msg_handle_init(msg_handle_t **hdl, cl_msg_type_t type,
-	process_msg_cb cb, void *arg);
 int cl_msg_handle_complete(cl_msg_t *msg);
-void cl_msg_handle_fini(msg_handle_t *hdl);
+
+static inline void cl_msg_set_rcode(cl_msg_t *msg, int rcode)
+{
+	msg->hdr.rcode = (u32)rcode;
+}
+
+static inline u32 cl_msg_get_rcode(cl_msg_t *msg)
+{
+	return msg->hdr.rcode;
+}
+
 
 #endif


### PR DESCRIPTION
should be a blocking call

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

we use a message queue to send a msg to the vmc_sc_comms task and block the entire loop at exact location for SCFW update.
We just need to add a response back to the caller when the SCFW update is finished with a return code.
 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected

block till SCFW done

#### Risks (if any) associated the changes in the commit

N/A

#### What has been tested and how, request additional testing if necessary

Tested with latest qdma shell. 

#### Documentation impact (if any)

N/A