### PR TITLE
VITIS-5847 Resilient VMR - add task,mem stats

### DIFF
--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -61,6 +61,8 @@ static struct xgq_cmd_cl_map xgq_cmd_log_page_map[] = {
 	{XGQ_CMD_LOG_FW, CL_LOG_FW},
 	{XGQ_CMD_LOG_INFO, CL_LOG_INFO},
 	{XGQ_CMD_LOG_ENDPOINT, CL_LOG_ENDPOINT},
+	{XGQ_CMD_LOG_TASK_STATS, CL_LOG_TASK_STATS},
+	{XGQ_CMD_LOG_MEM_STATS, CL_LOG_MEM_STATS},
 };
 
 static struct xgq_cmd_cl_map xgq_cmd_sensor_map[] = {

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -67,6 +67,8 @@ enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_INFO	= 0x2,
 	XGQ_CMD_LOG_AF_CLEAR	= 0x3,
 	XGQ_CMD_LOG_ENDPOINT	= 0x4,
+	XGQ_CMD_LOG_TASK_STATS	= 0x5,
+	XGQ_CMD_LOG_MEM_STATS	= 0x6,
 };
 
 /**

--- a/vmr/src/include/cl_msg.h
+++ b/vmr/src/include/cl_msg.h
@@ -36,6 +36,8 @@ typedef enum cl_log_type {
 	CL_LOG_INFO		= 0x3,
 	CL_LOG_AF_CLEAR		= 0x4,
 	CL_LOG_ENDPOINT		= 0x5,
+	CL_LOG_TASK_STATS	= 0x6,
+	CL_LOG_MEM_STATS	= 0x7,
 } cl_log_type_t;
 
 typedef enum cl_clock_type {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
add rtos task and memory stats

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-5847
#### How problem was solved, alternative solutions (if any) and why they were rejected
using freertos API to get human-readable task and memory stats 
#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary

## Before xbutil validate 
[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_mem_stats 
Available heap size: 233558184
Max size of free blocks in bytes: 233295720
Min size of free blocks in bytes: 216
Num of free blocks: 3
Min amount of free blocks since system booted: 233295936
Num of successful pvPortMalloc: 157
Num of successful pvPortFree: 3
[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_task_stats 
Name            State           Priority        Stack   Base
XGQ Opera       Running     1           65300   0x48107b40
IDLE            Ready       0           172     0x40084b98
XGQ Recei       Blocked     1           65452   0x48087b30
Sensor Mo       Blocked     1           65340   0x48147b48
Tmr Svc         Blocked     7           364     0x40085020
SC Common       Blocked     1           65310   0x48187b50
XGQ Progr       Blocked     1           65302   0x480c7b38
[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_mem_stats 
Available heap size: 233558184
Max size of free blocks in bytes: 233295720
Min size of free blocks in bytes: 216
Num of free blocks: 3
Min amount of free blocks since system booted: 233295936
Num of successful pvPortMalloc: 158
Num of successful pvPortFree: 4

## note: memory number is unchanged except malloc and free added 1 due to vmr_task_stats has to alloc dynamic array and free from heap

## after xbutil validate
## node: memory stays unchanged because we alloc memory staticlly. task stacks changed a little bit but within control.
we will monitor those dynamic numbers and use static compiler tools to measure memory usage in another PR.

[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_mem_stats 
Available heap size: 233558184
Max size of free blocks in bytes: 233295720
Min size of free blocks in bytes: 216
Num of free blocks: 3
Min amount of free blocks since system booted: 233295936
Num of successful pvPortMalloc: 158
Num of successful pvPortFree: 4
[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_task_stats 
Name            State           Priority        Stack   Base
XGQ Opera       Running     1           65300   0x48107b40
IDLE            Ready       0           172     0x40084b98
SC Common       Blocked     1           65310   0x48187b50
XGQ Recei       Blocked     1           65448   0x48087b30
Sensor Mo       Blocked     1           65340   0x48147b48
Tmr Svc         Blocked     7           364     0x40085020
XGQ Progr       Blocked     1           65302   0x480c7b38
[root@xsjyliu51 ~]# cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525953/vmr_mem_stats 
Available heap size: 233558184
Max size of free blocks in bytes: 233295720
Min size of free blocks in bytes: 216
Num of free blocks: 3
Min amount of free blocks since system booted: 233295936
Num of successful pvPortMalloc: 159
Num of successful pvPortFree: 5


#### Documentation impact (if any)
