### PR TITLE
VITIS-5847 Resilient VMR - linux dmesg style timestamp in VMR log

### DIFF
--- a/vmr/src/common/cl_log.c
+++ b/vmr/src/common/cl_log.c
@@ -66,6 +66,17 @@ static void vmr_log_collect(uint32_t msg_index_addr, uint32_t msg_buf_addr,
 	IO_SYNC_WRITE32(log_idx, msg_index_addr);
 }
 
+/* Current tick since boot to Seconds*/
+static inline u32 getCurrentSecond()
+{
+	return pdTICKS_TO_S(xTaskGetTickCount()); 
+}
+
+static inline u32 getCurrentMS()
+{
+	return pdTICKS_TO_MS(xTaskGetTickCount()) - getCurrentSecond() * 1000;
+}
+
 static void cl_printf_impl(const char *name, uint32_t line, uint8_t log_level,
 	const char *app_name, const char *fmt, va_list *argp)
 {
@@ -88,8 +99,8 @@ static void cl_printf_impl(const char *name, uint32_t line, uint8_t log_level,
 
 	/* assembile log message into log_buf char array */
 	vsnprintf(buf, sizeof(buf), fmt, *argp);
-	snprintf(log_buf, sizeof(log_buf), "[ %ld ] %s:%s:%ld: %s\r\n",
-		xTaskGetTickCount(), app_name, name, line, buf);
+	snprintf(log_buf, sizeof(log_buf), "[ %ld.%ld] %s:%s:%ld: %s\r\n",
+		getCurrentSecond(), getCurrentMS(), app_name, name, line, buf);
 
 	/* print to console */
 	xil_printf("%s", log_buf);

--- a/vmr/src/include/cl_log.h
+++ b/vmr/src/include/cl_log.h
@@ -13,12 +13,8 @@
 #include "cl_version.h"
 #include "cl_config.h"
 
-/*
- * The pdMS_TO_TICKS is defined as (xTimeInMs * configTICKRATEHZ) / 1000
- * so the pdTICKS_TO_MS can be the opposite way
- */
-#define pdTICKS_TO_MS( xTicks ) \
-	(( xTicks * 1000 ) / configTICKRATEHZ)
+#define pdTICKS_TO_MS(n) (n * 1000 / configTICK_RATE_HZ)
+#define pdTICKS_TO_S(n) (n / configTICK_RATE_HZ)
 
 /**
  * Application type id for logging, mem signature etc.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-5847

#### How problem was solved, alternative solutions (if any) and why they were rejected
covery ticks to linux dmesg style timestamp [ seconds.ms ]

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
xbmgmt program, xbutil reset, xbutil validate

#### Documentation impact (if any)
N/A