### PR TITLE
VITIS-5847 Resilient VMR - freertos heap is using bss

### DIFF
--- a/vmr/src/lscript.ld
+++ b/vmr/src/lscript.ld
@@ -15,8 +15,8 @@
 /*                                                                 */
 /*******************************************************************/
 
-_STACK_SIZE = DEFINED(_STACK_SIZE) ? _STACK_SIZE : 0x10000000;
-_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0xA000000;
+_STACK_SIZE = DEFINED(_STACK_SIZE) ? _STACK_SIZE : 0xA00000;
+_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0xA00000;
 
 _ABORT_STACK_SIZE = DEFINED(_ABORT_STACK_SIZE) ? _ABORT_STACK_SIZE : 1024;
 _SUPERVISOR_STACK_SIZE = DEFINED(_SUPERVISOR_STACK_SIZE) ? _SUPERVISOR_STACK_SIZE : 2048;


### PR DESCRIPTION
set stack and heap size to smaller size is ok

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
VITIS-5847

#### How problem was solved, alternative solutions (if any) and why they were rejected
We now use freertos heap for all tasks, so that no need to reserve too much memory for C stack/heap.
0xa00000 is 10MB, similar with linux OS.

xsjyliu51:build $ readelf -a vmr.elf |egrep "\.stack|\.heap|\.bss|ucHeap"
  [14] .bss              NOBITS          4003fb40 05fb08 16005404 00  WA  0   0 64
  [15] .heap             NOBITS          56044f44 05fb08 a0000c 00  WA  0   0  1
  [16] .stack            NOBITS          56a44f50 05fb08 a01800 00  WA  0   0  1
  868: 40044d04 0x16000000 OBJECT  LOCAL  DEFAULT   14 ucHeap

#### Risks (if any) associated the changes in the commit
We don't use malloc, so it is safe. We should not have recursive big call as well.

#### What has been tested and how, request additional testing if necessary
Tested with latest qdma shell.

#### Documentation impact (if any)
N/A