### PR TITLE
Fail safe SC update

### DIFF
--- a/vmr/src/common/cl_vmc_sc_comms.c
+++ b/vmr/src/common/cl_vmc_sc_comms.c
@@ -24,10 +24,10 @@
  *                                        +---> Fetch VOLT, POWER, TEMP, I2C
  */
 
-static void process_scfw_msg(cl_msg_t *msg)
+static int process_scfw_msg(cl_msg_t *msg)
 {
 	/* this is a blocking call */
-	(void) cl_vmc_scfw_program(msg);
+	return (cl_vmc_scfw_program(msg));
 }
 
 /*
@@ -47,11 +47,16 @@ int cl_vmc_sc_comms_init(void)
 void cl_vmc_sc_comms_func(void *task_args)
 {
 	cl_msg_t msg;
+	int ret = 0;
 
 	while (1) {
 		if (cl_recv_from_queue_nowait(&msg, CL_QUEUE_SCFW_REQ) == 0) {
-			process_scfw_msg(&msg);
+			ret = process_scfw_msg(&msg);
 			/* set correct rcode based on scfw program */
+			/*TODO: Here we need to return the ret value so that XRT will get
+			 * a valid error code if SC update fails in the middle. 
+			 * To enable this, we need a new XRT version. We will enable this in sync with XRT changes. */
+			VMR_ERR("SCFW Update return code: %02x", ret);
 			cl_msg_set_rcode(&msg, 0);
 			/* send msg back via SCFW Response Queue */
 			(void) cl_send_to_queue(&msg, CL_QUEUE_SCFW_RESP);

--- a/vmr/src/vmc/vmc_update_sc.h
+++ b/vmr/src/vmc/vmc_update_sc.h
@@ -41,6 +41,7 @@
 #define BSL_SYNC_SUCCESS		(0x00)
 #define SC_BSL_SYNCED_REQ_SIZE		(0x01)
 #define SC_BSL_SYNCED_RESP_SIZE		(0x0B)
+#define BSL_UNKNOWN_MSG_RESP_SIZE	(0x08)
 
 #define SC_ENABLE_BSL_REQ_SIZE		(0x09)
 #define SC_ENABLE_BSL_RESP_SIZE		(0x0B)
@@ -143,8 +144,8 @@ typedef enum sc_update_state_e
 
 typedef enum sc_update_error_e
 {
-	eSc_Update_No_Error = 0xE0,
-	eSc_Up_To_Date_No_Update_Req,
+	eSc_Update_No_Error = 0x00,
+	eSc_Up_To_Date_No_Update_Req = 0xE0,
 	eSc_Update_Error_Sc_Bsl_Sync_Failed,
 	eSc_Update_Error_En_Bsl_Failed,
 	eSc_Update_Error_Vmc_Bsl_Sync_Failed,


### PR DESCRIPTION
	- This patch adds fail safe SC update.

Signed-off-by: Sibasish Rout <sibasish.rout@amd.com>
This PR is a clone of https://github.com/Xilinx/VMR/pull/177.
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This patch adds fail safe SC update.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added few retries to detect the MSP mode.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
1. We ran "xbutil reset" followed by "xbutil validate" in a loop for approximately 15 hours without encountering any problems or asserts.
2. SC was updated more than 20 times without any issues (4.4.33 -> 4.4.35).
#### Documentation impact (if any)
NA