### PR TITLE
Fix for CR-1133643

### DIFF
--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -27,6 +27,16 @@ extern uart_rtos_handle_t uart_vmcsc_log;
 #define ETX                 (0x03)
 #define ESCAPE_CHAR         (0x5C)
 
+#define MSG_ID_OFFSET			(2u)
+#define FLAG_OFFSET			(3u)
+#define PAYLOAD_LEN_L_OFFSET		(4u)
+#define PAYLOAD_LEN_H_OFFSET		(5u)
+#define PAYLOAD_START_OFFSET_NO_FLAG	(5u)
+#define PAYLOAD_START_OFFSET_W_FLAG	(6u)
+#define CHECKSUM_L_OFFSET		(4u)
+#define CHECKSUM_H_OFFSET		(3u)
+#define TOTAL_FOOTER_SIZE		(4u)
+
 // board info sizes
 #define BOARD_NAME_SIZE     17
 #define BOARD_REV_SIZE      9
@@ -170,7 +180,7 @@ void Update_OEM_Data(u8 PayloadLength , u8 * Payload);
 void VMC_StoreSensor_Value(u8 id, u32 value);
 void VMC_Update_Sensors(u16 length,u8 *payload);
 void Update_SNSR_Data(u8 PayloadLength , u8 * payload);
-bool Parse_SCData(u8 *Payload);
+bool Parse_SCData(u8 *Payload, u8 expected_msgid);
 bool VMC_send_packet(u8 Message_id , u8 Flags,u8 Payloadlength, u8 *Payload);
 bool vmc_get_sc_status();
 void vmc_set_sc_status(bool value);


### PR DESCRIPTION
	- Before interpreting the SC packet it has just received, VMC now validates it's checksum.

Signed-off-by: Sibasish Rout <sibasish.rout@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Before interpreting the SC packet it has just received, VMC now validates it's checksum.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1133643
#### How problem was solved, alternative solutions (if any) and why they were rejected
Now we are validating the SC checksum before parsing it.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
1. We ran "xbutil reset" followed by "xbutil validate" in a loop for approximately 10 hours without encountering any problems or asserts.
2. Sensor values that we received from SC seem to be correct.
```
xbutil examine --report electrical thermal -d 0000:3b:00.1

-------------------------------------------------------
1/1 [0000:3b:00.1] : xilinx_vck5000_gen4x8_qdma_base_1
-------------------------------------------------------
Electrical
  Max Power              : NA Watts
  Power                  : 26 Watts
  Power Warning          : NA

  Power Rails            : Voltage   Current
  12v_pex                : 12.182 V,  0.877 A
  3v3_pex                :  3.293 V
  3v3_aux                :  3.297 V
  12v_aux_0              : 12.181 V,  1.238 A
  12v_aux_1              : 12.164 V,  0.303 A
  vccint                 :  0.801 V,  8.300 A

Thermals
  Temperature            : Celcius
  PCB                    :     26 C
  device                 :     36 C
  vccint                 :     35 C
  cage_temp_0            :     28 C
  cage_temp_1            :     30 C
```
#### Documentation impact (if any)
NA