### PR TITLE
Multiplatform UART config

### DIFF
--- a/vmr/src/common/cl_uart_rtos.c
+++ b/vmr/src/common/cl_uart_rtos.c
@@ -550,14 +550,19 @@ int32_t UART_RTOS_Disable(uart_rtos_handle_t *handle)
 * @note
 *
 **************************************************************************/
-s32 UART_RTOS_Debug_Enable(uart_rtos_handle_t *handle)
+s32 UART_RTOS_Debug_Enable(uart_rtos_handle_t *handle, ePlatformType curr_platform)
 {
 
 	static uart_rtos_config_t debugUartConig = {
 			.INTC_ID = XPAR_SCUGIC_SINGLE_DEVICE_ID,
-			.uart_ID = XPAR_XUARTPSV_1_DEVICE_ID,
-			.uart_IRQ_ID = XPAR_XUARTPS_1_INTR
+			.uart_ID = XPAR_XUARTPSV_0_DEVICE_ID,
+			.uart_IRQ_ID = XPAR_XUARTPS_0_INTR
 	};
+
+	if(curr_platform == eVCK5000){
+		debugUartConig.uart_ID = XPAR_XUARTPSV_1_DEVICE_ID;
+		debugUartConig.uart_IRQ_ID = XPAR_XUARTPS_1_INTR;
+	}
 
 	debugUartConig.uartHandler = handle;
 
@@ -568,14 +573,19 @@ s32 UART_RTOS_Debug_Enable(uart_rtos_handle_t *handle)
 	return UART_RTOS_Enable(&debugUartConig);
 }
 
-s32 UART_VMC_SC_Enable(uart_rtos_handle_t *handle)
+s32 UART_VMC_SC_Enable(uart_rtos_handle_t *handle, ePlatformType curr_platform)
 {
 
 	static uart_rtos_config_t vmcscUartConfig = {
 			.INTC_ID = XPAR_SCUGIC_SINGLE_DEVICE_ID,
-			.uart_ID = XPAR_XUARTPSV_0_DEVICE_ID,
-			.uart_IRQ_ID = XPAR_XUARTPS_0_INTR
+			.uart_ID = XPAR_XUARTPSV_1_DEVICE_ID,
+			.uart_IRQ_ID = XPAR_XUARTPS_1_INTR
 	};
+
+	if(curr_platform == eVCK5000){
+		vmcscUartConfig.uart_ID = XPAR_XUARTPSV_0_DEVICE_ID;
+		vmcscUartConfig.uart_IRQ_ID = XPAR_XUARTPS_0_INTR;
+	}
 
 	vmcscUartConfig.uartHandler = handle;
 

--- a/vmr/src/include/cl_uart_rtos.h
+++ b/vmr/src/include/cl_uart_rtos.h
@@ -14,6 +14,8 @@
 #include "xil_types.h"
 #include "xscugic.h"
 
+#include "../vmc/vmc_api.h"
+
 
 #define MAX_LOG_SIZE	(1024u)
 
@@ -61,8 +63,8 @@ int32_t UART_RTOS_Send(uart_rtos_handle_t *handle, uint8_t *buf, uint32_t size);
 int32_t UART_RTOS_Receive(uart_rtos_handle_t *handle, uint8_t *buf, uint32_t size, uint32_t *received,uint32_t timeout);
 int32_t UART_RTOS_Enable(uart_rtos_config_t *uartConfig);
 int32_t UART_RTOS_Disable(uart_rtos_handle_t *handle);
-int32_t UART_RTOS_Debug_Enable(uart_rtos_handle_t *handle);
-int32_t UART_VMC_SC_Enable(uart_rtos_handle_t *handle);
+int32_t UART_RTOS_Debug_Enable(uart_rtos_handle_t *handle, ePlatformType curr_platform);
+int32_t UART_VMC_SC_Enable(uart_rtos_handle_t *handle, ePlatformType curr_platform);
 
 
 #endif

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -79,14 +79,6 @@ int cl_vmc_init()
 {
 	s8 status = 0;
 
-#ifdef VMC_DEBUG
-	/* Enable FreeRTOS Debug UART */
-	if (UART_RTOS_Debug_Enable(&uart_log) != XST_SUCCESS) {
-		return -ENODEV;
-	}
-	/* Demo Menu is already enabled by cl_main task handler */
-#endif
-
 	cl_I2CInit();
 
 	/* Read the EEPROM */
@@ -104,20 +96,25 @@ int cl_vmc_init()
 		return -EINVAL;
 	}
 
+#ifdef VMC_DEBUG
+	/* Enable FreeRTOS Debug UART */
+	if (UART_RTOS_Debug_Enable(&uart_log, current_platform) != XST_SUCCESS) {
+		return -ENODEV;
+	}
+	/* Demo Menu is already enabled by cl_main task handler */
+#endif
+
 	status = Init_Platform();
 	if (status != XST_SUCCESS) {
 		VMR_ERR("Platform Initialization Failed.");
 		return -EINVAL;
 	}
 
-	status = UART_VMC_SC_Enable(&uart_vmcsc_log);
+	status = UART_VMC_SC_Enable(&uart_vmcsc_log, current_platform);
 	if (status != XST_SUCCESS) {
 		VMR_ERR("UART VMC to SC init Failed.");
 		return -EINVAL;
 	}
-
-//	/* Retry till fan controller is programmed */
-//	while (max6639_init(1, 0x2E));  // only for vck5000
 
 	/* sdr_lock */
 	sdr_lock = xSemaphoreCreateMutex();


### PR DESCRIPTION
-Swap uart 0/1 for debug and SC communication  based on the current platform

Signed off by Shahab Alilou <shahaba@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
UART 0 and 1 is swapped in V70 and onward.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Printed data out on console with VMC_DEBUG enabled/disabled
#### Documentation impact (if any)
