### PR TITLE
Added EEPROM 3.0 support

### DIFF
--- a/vmr/src/vmc/vmc_api.c
+++ b/vmr/src/vmc/vmc_api.c
@@ -40,6 +40,43 @@ static char LogBuf[MAX_LOG_SIZE];
 
 void Debug_Printf(char *filename, u32 line, u8 log_level, const char *fmt, va_list *argp);
 
+EEPROM_Content_Details_t Ver_3_0_Offset_Size[eEeprom_max_Offset] =
+{
+	{EEPROM_V3_0_PRODUCT_NAME_OFFSET, EEPROM_V3_0_PRODUCT_NAME_SIZE},
+	{EEPROM_V3_0_BOARD_REV_OFFSET, EEPROM_V3_0_BOARD_REV_SIZE},
+	{EEPROM_V3_0_BOARD_SERIAL_OFFSET, EEPROM_V3_0_BOARD_SERIAL_SIZE},
+	{EEPROM_V3_0_BOARD_TOT_MAC_ID_OFFSET, EEPROM_V3_0_BOARD_TOT_MAC_ID_SIZE},
+	{EEPROM_V3_0_BOARD_MAC_OFFSET, EEPROM_V3_0_BOARD_MAC_SIZE},
+	{EEPROM_V3_0_BOARD_ACT_PAS_OFFSET, EEPROM_V3_0_BOARD_ACT_PAS_SIZE},
+	{EEPROM_V3_0_BOARD_CONFIG_MODE_OFFSET, EEPROM_V3_0_BOARD_CONFIG_MODE_SIZE},
+	{EEPROM_V3_0_MFG_DATE_OFFSET, EEPROM_V3_0_MFG_DATE_SIZE},
+	{EEPROM_V3_0_PART_NUM_OFFSET, EEPROM_V3_0_PART_NUM_SIZE},
+	{EEPROM_V3_0_UUID_OFFSET, EEPROM_V3_0_UUID_SIZE},
+	{EEPROM_V3_0_PCIE_INFO_OFFSET, EEPROM_V3_0_PCIE_INFO_SIZE},
+	{EEPROM_V3_0_MAX_POWER_MODE_OFFSET, EEPROM_V3_0_MAX_POWER_MODE_SIZE},
+	{EEPROM_V3_0_DIMM_SIZE_OFFSET, EEPROM_V3_0_DIMM_SIZE_SIZE},
+	{EEPROM_V3_0_OEMID_SIZE_OFFSET, EEPROM_V3_0_OEMID_SIZE},
+	{EEPROM_V3_0_CAPABILITY_OFFSET, EEPROM_V3_0_CAPABILITY_SIZE},
+};
+
+EEPROM_Content_Details_t Ver_2_0_Offset_Size[eEeprom_max_Offset] =
+{
+	{EEPROM_V2_0_PRODUCT_NAME_OFFSET, EEPROM_V2_0_PRODUCT_NAME_SIZE},
+	{EEPROM_V2_0_BOARD_REV_OFFSET, EEPROM_V2_0_BOARD_REV_SIZE},
+	{EEPROM_V2_0_BOARD_SERIAL_OFFSET, EEPROM_V2_0_BOARD_SERIAL_SIZE},
+	{EEPROM_V2_0_BOARD_TOT_MAC_ID_OFFSET, EEPROM_V2_0_BOARD_NUM_MAC},
+	{EEPROM_V2_0_BOARD_MAC_OFFSET, EEPROM_V2_0_BOARD_MAC_SIZE},
+	{EEPROM_V2_0_BOARD_ACT_PAS_OFFSET, EEPROM_V2_0_BOARD_ACT_PAS_SIZE},
+	{EEPROM_V2_0_BOARD_CONFIG_MODE_OFFSET, EEPROM_V2_0_BOARD_CONFIG_MODE_SIZE},
+	{EEPROM_V2_0_MFG_DATE_OFFSET, EEPROM_V2_0_MFG_DATE_SIZE},
+	{EEPROM_V2_0_PART_NUM_OFFSET, EEPROM_V2_0_PART_NUM_SIZE},
+	{EEPROM_V2_0_UUID_OFFSET, EEPROM_V2_0_UUID_SIZE},
+	{EEPROM_V2_0_PCIE_INFO_OFFSET, EEPROM_V2_0_PCIE_INFO_SIZE},
+	{EEPROM_V2_0_MAX_POWER_MODE_OFFSET, EEPROM_V2_0_MAX_POWER_MODE_SIZE},
+	{EEPROM_V2_0_DIMM_SIZE_OFFSET, EEPROM_V2_0_DIMM_SIZE_SIZE},
+	{EEPROM_V2_0_OEMID_SIZE_OFFSET, EEPROM_V2_0_OEMID_SIZE},
+	{EEPROM_V2_0_CAPABILITY_OFFSET, EEPROM_V2_0_CAPABILITY_SIZE},
+};
 
 void VMC_SetLogLevel(u8 LogLevel)
 {
@@ -124,23 +161,32 @@ void Debug_Printf(char *filename, u32 line, u8 log_level, const char *fmt, va_li
 
 void BoardInfoTest(void)
 {
-	u16 mac_num     = 0;
+	u16 mac_num = 0;
+
 	//VMC_LOG("\n\rTBD: Board Info to be printed! %d",1000);
-	VMC_DMO( "EEPROM Version        : %s \n\r",board_info.eeprom_version);
+	VMC_DMO( "EEPROM Version         : %s \n\r",board_info.eeprom_version);
 	VMC_DMO( "product name          : %s \n\r",board_info.product_name);
 	VMC_DMO( "board rev             : %s \n\r",board_info.board_rev);
 	VMC_DMO( "board serial          : %s \n\r",board_info.board_serial);
 
 	/* Print MAC info */
-	for(mac_num = 0; mac_num < EEPROM_BOARD_NUM_MAC; mac_num++)
+	VMR_LOG("Board MAC%d            : %02x:%02x:%02x:%02x:%02x:%02x\n\r", mac_num,
+						board_info.board_mac[mac_num][0],
+						board_info.board_mac[mac_num][1],
+						board_info.board_mac[mac_num][2],
+						board_info.board_mac[mac_num][3],
+						board_info.board_mac[mac_num][4],
+	                                        board_info.board_mac[mac_num][5]);
+
+	for (mac_num = 1; mac_num < board_info.Num_MAC_IDS; mac_num++)
 	{
 		VMC_DMO("Board MAC%d            : %02x:%02x:%02x:%02x:%02x:%02x\n\r", mac_num, 
-									       board_info.board_mac[mac_num][0],
-									       board_info.board_mac[mac_num][1],
-									       board_info.board_mac[mac_num][2],
-									       board_info.board_mac[mac_num][3],
-					                                       board_info.board_mac[mac_num][4],
-                                                                               board_info.board_mac[mac_num][5]);
+							board_info.board_mac[mac_num][0],
+							board_info.board_mac[mac_num][1],
+							board_info.board_mac[mac_num][2],
+							board_info.board_mac[mac_num][3],
+					                board_info.board_mac[mac_num][4],
+							board_info.board_mac[mac_num][5]);
 	}
 
 	VMC_DMO( "board A/P             : %s \n\r",board_info.board_act_pas);
@@ -189,6 +235,9 @@ void BoardInfoTest(void)
                                                           board_info.OEM_ID[2],
                                                           board_info.OEM_ID[1],
                                                           board_info.OEM_ID[0]);
+
+	VMR_LOG( "Capability            : %02x%02x\n\r", board_info.capability[1],
+							 board_info.capability[0]);
 }
 
 void SensorData_Display(void)
@@ -238,256 +287,167 @@ void VMC_Get_BoardInfo(Versal_BoardInfo *_board_info) {
 			&board_info, sizeof(Versal_BoardInfo));
 }
 
+u8 Update_BoardInfo_Data(u8 i2c_num, u8 *data_ptr, u16 offset, u8 size)
+{
+	u8 status = 0;
+
+	for (int i = 0; i < size; i++)
+	{
+		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
+		if (data_ptr[i] == EEPROM_DEFAULT_VAL) {
+			data_ptr[i] = '\0';
+		}
+		offset = offset + 0x0100;
+	}
+	/* Explicitly set \0 at the end of board name string */
+	data_ptr[size] = '\0';
+
+	return status;
+}
+
 u8 Versal_EEPROM_ReadBoardInfo(void)
 {
-	s8 i			= 0;
-	u16 offset		= 0x00;
-	u8  status              = 0;
-	u8  MAC_ID[6] 	        = {0};
-	u16 Value 		= 0;
-	u8  carry 		= 0;
-	u16 mac_num             = 0;
-	u8 i2c_num 		= 1;
+	s8 i = 0;
+	u16 offset = 0x00;
+	u8 status = 0;
+	u8 MAC_ID[6] = { 0 };
+	u16 Value = 0;
+	u8 carry = 0;
+	u16 mac_num = 0;
+	u8 i2c_num = 1;
+	u32 eeprom_ver = 0;
+	u8 size = 0;
 
-	unsigned char *data_ptr = NULL;
-	data_ptr = board_info.eeprom_version;
-	offset = EEPROM_VERSION_OFFSET;
+	EEPROM_Content_Details_t *eeprom_offset = NULL;
 
-	for (i = 0 ; i < EEPROM_VERSION_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
+	u8 *data_ptr = NULL;
 
-        	if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-        	{
-            		data_ptr[i] = '\0';
-        	}
-        	offset = offset + 0x0100;
+	status = Update_BoardInfo_Data(i2c_num, board_info.eeprom_version,
+			EEPROM_VERSION_OFFSET, EEPROM_VERSION_SIZE);
+	if (status != XST_SUCCESS) {
+		VMR_ERR("EEPROM version read failed !!");
+		return XST_FAILURE;
 	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_VERSION_SIZE] = '\0';
 
-
-	data_ptr = board_info.product_name;
-	offset   = EEPROM_PRODUCT_NAME_OFFSET;
-	for (i = 0 ; i < EEPROM_PRODUCT_NAME_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-
-        	if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-        	{
-            		data_ptr[i] = '\0';
-        	}
-        	offset = offset + 0x0100;
+	eeprom_ver = ((board_info.eeprom_version[0] << 16)
+					| (board_info.eeprom_version[1] << 8)
+					| (board_info.eeprom_version[2]));
+	if (eeprom_ver == EEPROM_V3_0) {
+		eeprom_offset = Ver_3_0_Offset_Size;
+	} else if (eeprom_ver == EEPROM_V2_0) {
+		eeprom_offset = Ver_2_0_Offset_Size;
+	} else {
+		VMR_ERR("Unable to identify MFG EEPROM version !!");
+		return XST_FAILURE;
 	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_PRODUCT_NAME_SIZE] = '\0';
+	VMR_LOG("MFG EEPROM Version is %s",&board_info.eeprom_version[0]);
 
-	data_ptr = board_info.board_rev;
-	offset   = EEPROM_BOARD_REV_OFFSET;
-	for (i = 0 ; i < EEPROM_BOARD_REV_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
+	status = Update_BoardInfo_Data(i2c_num, board_info.product_name,
+			eeprom_offset[eEeprom_Product_Name].offset,
+			eeprom_offset[eEeprom_Product_Name].size);
+	if (status != XST_SUCCESS) {
+		VMR_ERR("Unable to read product name !!");
+		return XST_FAILURE;
+	}
 
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_rev,
+			eeprom_offset[eEeprom_Board_Rev].offset,
+			eeprom_offset[eEeprom_Board_Rev].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_serial,
+			eeprom_offset[eEeprom_Board_Serial].offset,
+			eeprom_offset[eEeprom_Board_Serial].size);
+
+	if (eeprom_offset[eEeprom_Board_Tot_Mac_Id].offset != EEPROM_V2_0_BOARD_TOT_MAC_ID_OFFSET) {
+		status = Update_BoardInfo_Data(i2c_num, &board_info.Num_MAC_IDS,
+				eeprom_offset[eEeprom_Board_Tot_Mac_Id].offset,
+				eeprom_offset[eEeprom_Board_Tot_Mac_Id].size);
+		if (board_info.Num_MAC_IDS == 0) {
+			board_info.Num_MAC_IDS = 1;
 		}
-		offset = offset + 0x0100;
+	} else {
+		board_info.Num_MAC_IDS = eeprom_offset[eEeprom_Board_Tot_Mac_Id].size;
 	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_BOARD_REV_SIZE] = '\0';
-
-	data_ptr = board_info.board_serial;
-	offset   = EEPROM_BOARD_SERIAL_OFFSET;
-	for (i = 0 ; i < EEPROM_BOARD_SERIAL_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_BOARD_SERIAL_SIZE] = '\0';
-
-	board_info.Num_MAC_IDS = EEPROM_BOARD_NUM_MAC;
 
 	data_ptr = &board_info.board_mac[0][0];
-	offset = EEPROM_BOARD_MAC_OFFSET;
-	for (i = 0 ; i < EEPROM_BOARD_MAC_SIZE ; i++)
+	offset = eeprom_offset[eEeprom_Board_Mac].offset;
+	size = eeprom_offset[eEeprom_Board_Mac].size;
+	for (i = 0; i < size; i++)
 	{
 		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
 		offset = offset + 0x0100;
-
 	}
 	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_BOARD_MAC_SIZE] = '\0';
+	data_ptr[size] = '\0';
 
-    	for (i=0 ; i<EEPROM_BOARD_MAC_SIZE ; i++) //copy first MAC ID into MAC_ID
-    	{
-       		MAC_ID[i] = data_ptr[i];
-    	}
-
-    	for (mac_num = 1; mac_num < EEPROM_BOARD_NUM_MAC; mac_num++)
-    	{
-        	for (i = EEPROM_BOARD_MAC_SIZE-1 ; i >= 0 ; i--)
-        	{
-            		Value = MAC_ID[i] + 1;
-            		carry = (Value > 255) ? 1 : 0;
-            		if (carry == 1)
-            		{
-                		MAC_ID[i] = 0x00;
-                		continue;
-            		}
-            		else
-            		{
-                		MAC_ID[i] = Value;
-                		break;
-           		 }
-        	}
-        	for (i=0 ; i<EEPROM_BOARD_MAC_SIZE ; i++)
-        	{
-            		board_info.board_mac[mac_num][i] = MAC_ID[i];
-       	 	}
-        	board_info.board_mac[mac_num][EEPROM_BOARD_MAC_SIZE] = '\0';
-    	}
-
-
-    	data_ptr = board_info.board_act_pas;
-	offset   = EEPROM_BOARD_ACT_PAS_OFFSET;
-	for (i = 0 ; i < EEPROM_BOARD_ACT_PAS_SIZE ; i++)
+	for (i = 0; i < size; i++) //copy first MAC ID into MAC_ID
 	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
+		MAC_ID[i] = data_ptr[i];
+	}
 
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
+	for (mac_num = 1; mac_num < board_info.Num_MAC_IDS; mac_num++)
+	{
+		for (i = size - 1; i >= 0; i--)
 		{
-			data_ptr[i] = '\0';
+			Value = MAC_ID[i] + 1;
+			carry = (Value > 255) ? 1 : 0;
+			if (carry == 1) {
+				MAC_ID[i] = 0x00;
+				continue;
+			} else {
+				MAC_ID[i] = Value;
+				break;
+			}
 		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_BOARD_ACT_PAS_SIZE] = '\0';
-
-	data_ptr = board_info.board_config_mode;
-	offset   = EEPROM_BOARD_CONFIG_MODE_OFFSET;
-	for (i = 0 ; i < EEPROM_BOARD_CONFIG_MODE_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
+		for (i = 0; i < size; i++) {
+			board_info.board_mac[mac_num][i] = MAC_ID[i];
 		}
-		offset = offset + 0x0100;
+		board_info.board_mac[mac_num][size] = '\0';
 	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_BOARD_CONFIG_MODE_SIZE] = '\0';
 
-	data_ptr = board_info.board_mfg_date;
-	offset   = EEPROM_MFG_DATE_OFFSET;
-	for (i = 0 ; i < EEPROM_MFG_DATE_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_act_pas,
+			eeprom_offset[eEeprom_Board_Act_Pas].offset,
+			eeprom_offset[eEeprom_Board_Act_Pas].size);
 
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_config_mode,
+			eeprom_offset[eEeprom_Board_config_Mode].offset,
+			eeprom_offset[eEeprom_Board_config_Mode].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_mfg_date,
+			eeprom_offset[eEeprom_Mfg_Date].offset,
+			eeprom_offset[eEeprom_Mfg_Date].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_part_num,
+			eeprom_offset[eEeprom_Part_Num].offset,
+			eeprom_offset[eEeprom_Part_Num].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_uuid,
+			eeprom_offset[eEeprom_Uuid].offset,
+			eeprom_offset[eEeprom_Uuid].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_pcie_info,
+			eeprom_offset[eEeprom_Pcie_Info].offset,
+			eeprom_offset[eEeprom_Pcie_Info].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.board_max_power_mode,
+			eeprom_offset[eEeprom_Max_Power_Mode].offset,
+			eeprom_offset[eEeprom_Max_Power_Mode].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.Memory_size,
+			eeprom_offset[eEeprom_Dimm_Size].offset,
+			eeprom_offset[eEeprom_Dimm_Size].size);
+
+	status = Update_BoardInfo_Data(i2c_num, board_info.OEM_ID,
+			eeprom_offset[eEeprom_Oemid_Size].offset,
+			eeprom_offset[eEeprom_Oemid_Size].size);
+
+	if (eeprom_offset[eEeprom_Capability_Word].offset != EEPROM_V2_0_CAPABILITY_OFFSET) {
+		status = Update_BoardInfo_Data(i2c_num, board_info.capability,
+				eeprom_offset[eEeprom_Capability_Word].offset,
+				eeprom_offset[eEeprom_Capability_Word].size);
 	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_MFG_DATE_SIZE] = '\0';
 
-	data_ptr = board_info.board_part_num;
-	offset   = EEPROM_PART_NUM_OFFSET;
-	for (i = 0 ; i < EEPROM_PART_NUM_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_PART_NUM_SIZE] = '\0';
-
-	data_ptr = board_info.board_uuid;
-	offset   = EEPROM_UUID_OFFSET;
-	for (i = 0 ; i < EEPROM_UUID_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_UUID_SIZE] = '\0';
-
-	data_ptr = board_info.board_pcie_info;
-	offset   = EEPROM_PCIE_INFO_OFFSET;
-	for (i = 0 ; i < EEPROM_PCIE_INFO_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_PCIE_INFO_SIZE] = '\0';
-
-	data_ptr = board_info.board_max_power_mode;
-	offset   = EEPROM_MAX_POWER_MODE_OFFSET;
-	for (i = 0 ; i < EEPROM_MAX_POWER_MODE_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_MAX_POWER_MODE_SIZE] = '\0';
-
-	data_ptr = board_info.Memory_size;
-	offset   = EEPROM_DIMM_SIZE_OFFSET;
-	for (i = 0 ; i < EEPROM_DIMM_SIZE_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_DIMM_SIZE_SIZE] = '\0';
-
-	data_ptr = board_info.OEM_ID;
-	offset   = EEPROM_OEMID_SIZE_OFFSET;
-	for (i = 0 ; i < EEPROM_OEMID_SIZE ; i++)
-	{
-		status = M24C128_ReadByte(i2c_num, SLAVE_ADDRESS_M24C128, &offset, &data_ptr[i]);
-
-		if (data_ptr[i] == EEPROM_DEFAULT_VAL)
-		{
-			data_ptr[i] = '\0';
-		}
-		offset = offset + 0x0100;
-	}
-	/* Explicitly set \0 at the end of board name string */
-	data_ptr[EEPROM_OEMID_SIZE] = '\0';
-
-return status;
+	return status;
 }
 
 

--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -71,51 +71,131 @@
 #define __FILENAME__                 (strrchr(__FILE__, '/') ? (strrchr(__FILE__, '/')+1) : __FILE__)
 #endif
 
+/* Current EEPROM versions that VMR supports */
+#define EEPROM_V3_0               (0x332E30u)
+#define EEPROM_V2_0               (0x322E30u)
+
 /* Default register content in EEPROM if a particular register has not been programmed */
-#define EEPROM_DEFAULT_VAL               0xFF
+#define EEPROM_DEFAULT_VAL			0xFF
 
-#define EEPROM_VERSION_OFFSET            0x0000
-#define EEPROM_VERSION_SIZE              3
+#define EEPROM_VERSION_OFFSET            	0x0000
+#define EEPROM_VERSION_SIZE              	3
 
-#define EEPROM_PRODUCT_NAME_OFFSET       0x0300
-#define EEPROM_PRODUCT_NAME_SIZE         16
+#define EEPROM_V2_0_PRODUCT_NAME_OFFSET       	0x0300
+#define EEPROM_V2_0_PRODUCT_NAME_SIZE         	16
 
-#define EEPROM_BOARD_REV_OFFSET          0x1300
-#define EEPROM_BOARD_REV_SIZE            8
+#define EEPROM_V2_0_BOARD_REV_OFFSET          	0x1300
+#define EEPROM_V2_0_BOARD_REV_SIZE            	8
 
-#define EEPROM_BOARD_SERIAL_OFFSET       0x1B00
-#define EEPROM_BOARD_SERIAL_SIZE         14
+#define EEPROM_V2_0_BOARD_SERIAL_OFFSET       	0x1B00
+#define EEPROM_V2_0_BOARD_SERIAL_SIZE         	14
 
-#define EEPROM_BOARD_MAC_OFFSET          0x2900 // EEPROM offset for the first MAC address
-#define EEPROM_BOARD_MAC_SIZE            6
-#define EEPROM_BOARD_NUM_MAC             2    // The EEPROM has 4 MAC addresses
+#define EEPROM_V2_0_BOARD_MAC_OFFSET          	0x2900
+#define EEPROM_V2_0_BOARD_MAC_SIZE            	6
 
-#define EEPROM_BOARD_ACT_PAS_OFFSET      0x4100
-#define EEPROM_BOARD_ACT_PAS_SIZE        1
+#define EEPROM_V2_0_BOARD_TOT_MAC_ID_OFFSET   	0xFFFF /* Not present in v2.0 version */
+#define EEPROM_V2_0_BOARD_NUM_MAC             	2
 
-#define EEPROM_BOARD_CONFIG_MODE_OFFSET  0x4200
-#define EEPROM_BOARD_CONFIG_MODE_SIZE    1
+#define EEPROM_V2_0_BOARD_ACT_PAS_OFFSET      	0x4100
+#define EEPROM_V2_0_BOARD_ACT_PAS_SIZE        	1
 
-#define EEPROM_MFG_DATE_OFFSET           0x4300
-#define EEPROM_MFG_DATE_SIZE             3
+#define EEPROM_V2_0_BOARD_CONFIG_MODE_OFFSET  	0x4200
+#define EEPROM_V2_0_BOARD_CONFIG_MODE_SIZE    	1
 
-#define EEPROM_PART_NUM_OFFSET           0x4600
-#define EEPROM_PART_NUM_SIZE             9
+#define EEPROM_V2_0_MFG_DATE_OFFSET           	0x4300
+#define EEPROM_V2_0_MFG_DATE_SIZE             	3
 
-#define EEPROM_UUID_OFFSET               0x4F00
-#define EEPROM_UUID_SIZE                 16
+#define EEPROM_V2_0_PART_NUM_OFFSET           	0x4600
+#define EEPROM_V2_0_PART_NUM_SIZE             	9
 
-#define EEPROM_PCIE_INFO_OFFSET          0x5F00
-#define EEPROM_PCIE_INFO_SIZE            8
+#define EEPROM_V2_0_UUID_OFFSET               	0x4F00
+#define EEPROM_V2_0_UUID_SIZE                 	16
 
-#define EEPROM_MAX_POWER_MODE_OFFSET     0x6700
-#define EEPROM_MAX_POWER_MODE_SIZE       1
+#define EEPROM_V2_0_PCIE_INFO_OFFSET          	0x5F00
+#define EEPROM_V2_0_PCIE_INFO_SIZE            	8
 
-#define EEPROM_DIMM_SIZE_OFFSET          0x6800
-#define EEPROM_DIMM_SIZE_SIZE            4
+#define EEPROM_V2_0_MAX_POWER_MODE_OFFSET     	0x6700
+#define EEPROM_V2_0_MAX_POWER_MODE_SIZE       	1
 
-#define EEPROM_OEMID_SIZE_OFFSET         0x6C00
-#define EEPROM_OEMID_SIZE                4
+#define EEPROM_V2_0_DIMM_SIZE_OFFSET          	0x6800
+#define EEPROM_V2_0_DIMM_SIZE_SIZE            	4
+
+#define EEPROM_V2_0_OEMID_SIZE_OFFSET		0x6C00
+#define EEPROM_V2_0_OEMID_SIZE                	4
+
+#define EEPROM_V2_0_CAPABILITY_OFFSET         	0xFFFF /* Not present in v2.0 version */
+#define EEPROM_V2_0_CAPABILITY_SIZE           	0
+
+#define EEPROM_V3_0_PRODUCT_NAME_OFFSET       	0x0800
+#define EEPROM_V3_0_PRODUCT_NAME_SIZE         	24
+
+#define EEPROM_V3_0_BOARD_REV_OFFSET          	0x2000
+#define EEPROM_V3_0_BOARD_REV_SIZE            	8
+
+#define EEPROM_V3_0_BOARD_SERIAL_OFFSET       	0x2800
+#define EEPROM_V3_0_BOARD_SERIAL_SIZE         	14
+
+#define EEPROM_V3_0_BOARD_TOT_MAC_ID_OFFSET   	0x3600
+#define EEPROM_V3_0_BOARD_TOT_MAC_ID_SIZE	1
+
+#define EEPROM_V3_0_BOARD_MAC_OFFSET          	0x3700
+#define EEPROM_V3_0_BOARD_MAC_SIZE            	6
+
+#define EEPROM_V3_0_BOARD_ACT_PAS_OFFSET      	0x3D00
+#define EEPROM_V3_0_BOARD_ACT_PAS_SIZE        	1
+
+#define EEPROM_V3_0_BOARD_CONFIG_MODE_OFFSET  	0x3E00
+#define EEPROM_V3_0_BOARD_CONFIG_MODE_SIZE    	1
+
+#define EEPROM_V3_0_MFG_DATE_OFFSET           	0x3F00
+#define EEPROM_V3_0_MFG_DATE_SIZE             	3
+
+#define EEPROM_V3_0_PART_NUM_OFFSET           	0x4200
+#define EEPROM_V3_0_PART_NUM_SIZE             	24
+
+#define EEPROM_V3_0_UUID_OFFSET               	0x5A00
+#define EEPROM_V3_0_UUID_SIZE                 	16
+
+#define EEPROM_V3_0_PCIE_INFO_OFFSET          	0x6A00
+#define EEPROM_V3_0_PCIE_INFO_SIZE            	8
+
+#define EEPROM_V3_0_MAX_POWER_MODE_OFFSET     	0x7200
+#define EEPROM_V3_0_MAX_POWER_MODE_SIZE       	1
+
+#define EEPROM_V3_0_DIMM_SIZE_OFFSET          	0x7300
+#define EEPROM_V3_0_DIMM_SIZE_SIZE            	4
+
+#define EEPROM_V3_0_OEMID_SIZE_OFFSET         	0x7700
+#define EEPROM_V3_0_OEMID_SIZE                	4
+
+#define EEPROM_V3_0_CAPABILITY_OFFSET         	0x7B00
+#define EEPROM_V3_0_CAPABILITY_SIZE           	2
+
+typedef enum eeprom_data_e
+{
+	eEeprom_Product_Name,
+	eEeprom_Board_Rev,
+	eEeprom_Board_Serial,
+	eEeprom_Board_Tot_Mac_Id,
+	eEeprom_Board_Mac,
+	eEeprom_Board_Act_Pas,
+	eEeprom_Board_config_Mode,
+	eEeprom_Mfg_Date,
+	eEeprom_Part_Num,
+	eEeprom_Uuid,
+	eEeprom_Pcie_Info,
+	eEeprom_Max_Power_Mode,
+	eEeprom_Dimm_Size,
+	eEeprom_Oemid_Size,
+	eEeprom_Capability_Word,
+	eEeprom_max_Offset,
+} eEEPROM_Offsets_t;
+
+typedef struct eeprom_data_s
+{
+	u16 offset;
+	u8 size;
+} EEPROM_Content_Details_t;
 
 
 typedef struct Versal_BoardInfo
@@ -136,6 +216,7 @@ typedef struct Versal_BoardInfo
     unsigned char OEM_ID[5];
     unsigned char DIMM_size[5];
     unsigned char Num_MAC_IDS;
+    unsigned char capability[2];
 } Versal_BoardInfo;
 
 #define 	MAX_PLATFORM_NAME_LEN (20u)

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -49,6 +49,7 @@ Platform_Sensor_Handler_t platform_sensor_handlers[]=
 	{eV70,eTemperature_Sensor_Inlet,V70_Temperature_Read_Inlet},
 	{eV70,eTemperature_Sensor_Outlet,V70_Temperature_Read_Outlet},
 	{eV70,eTemperature_Sensor_Board,V70_Temperature_Read_Board},
+	{eV70, eTemperature_Sensor_QSFP, NULL},
 };
 
 Platform_Function_Handler_t platform_function_handlers[]=

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -425,21 +425,33 @@ done:
 
 s8 Temperature_Read_Inlet(snsrRead_t *snsrData)
 {
+	if (Temperature_Read_Inlet_Ptr == NULL)
+		return XST_SUCCESS;
+
 	return (*Temperature_Read_Inlet_Ptr)(snsrData);
 }
 
 s8 Temperature_Read_Outlet(snsrRead_t *snsrData)
 {
+	if (Temperature_Read_Outlet_Ptr == NULL)
+		return XST_SUCCESS;
+
 	return (*Temperature_Read_Outlet_Ptr)(snsrData);
 }
 
 s8 Temperature_Read_Board(snsrRead_t *snsrData)
 {
+	if (Temperature_Read_Board_Ptr == NULL)
+		return XST_SUCCESS;
+
 	return (*Temperature_Read_Board_Ptr)(snsrData);
 }
 
 s8 Temperature_Read_QSFP(snsrRead_t *snsrData)
 {
+	if (Temperature_Read_QSFP_Ptr == NULL)
+		return XST_SUCCESS;
+
 	return (*Temperature_Read_QSFP_Ptr)(snsrData);
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Now, VMR will adjust its offsets for the board info based on the EEPROM version.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed the offsets based on EEPROM version.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Board Info looks ok for V70.
```
[ 0.90] VMR:BoardInfoTest:289: EEPROM Version         : 3.0

[ 0.90] VMR:BoardInfoTest:290: product name           : ALVEO V70 ES2

[ 0.100] VMR:BoardInfoTest:291: board rev             : A

[ 0.100] VMR:BoardInfoTest:292: board serial          : 51171A226N0X

[ 0.110] VMR:BoardInfoTest:295: Board MAC0            : 00:0a:35:0b:50:5c

[ 0.120] VMR:BoardInfoTest:314: board A/P             : P

[ 0.120] VMR:BoardInfoTest:316: board config mode     : 08

[ 0.130] VMR:BoardInfoTest:318: MFG DATE              : 768ed4

[ 0.130] VMR:BoardInfoTest:323: board part num        : 05117-01

[ 0.140] VMR:BoardInfoTest:325: UUID                  : bcb49f77-890a-5180-db42-09ef07fab207

[ 0.150] VMR:BoardInfoTest:343: PCIe Info             : 10ee, 5004, 10ee, 00ee

[ 0.160] VMR:BoardInfoTest:356: OEM ID                : 000010da
```
#### Documentation impact (if any)
NA