### PR TITLE
Generic UART config for SC Comms

### DIFF
--- a/vmr/src/include/cl_uart_rtos.h
+++ b/vmr/src/include/cl_uart_rtos.h
@@ -61,7 +61,7 @@ typedef struct _uart_rtos_config_t{
 
 int32_t UART_RTOS_Send(uart_rtos_handle_t *handle, uint8_t *buf, uint32_t size);
 int32_t UART_RTOS_Receive(uart_rtos_handle_t *handle, uint8_t *buf, uint32_t size, uint32_t *received,uint32_t timeout);
-int32_t UART_RTOS_Enable(uart_rtos_config_t *uartConfig);
+int32_t UART_RTOS_Enable(uart_rtos_config_t *uartConfig, ePlatformType curr_platform);
 int32_t UART_RTOS_Disable(uart_rtos_handle_t *handle);
 int32_t UART_RTOS_Debug_Enable(uart_rtos_handle_t *handle, ePlatformType curr_platform);
 int32_t UART_VMC_SC_Enable(uart_rtos_handle_t *handle, ePlatformType curr_platform);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
UART config made generic based on platform.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
The config section made generic for uart0/uart1.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
With this patch, VMC can communicate with SC in the case of v70.
#### Documentation impact (if any)
NA