### PR TITLE
Fix for CR-1137708

### DIFF
--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -395,5 +395,6 @@ extern sensorMonitorFunc Temperature_Read_QSFP_Ptr;
 
 void VMC_Get_BoardInfo(Versal_BoardInfo *ptr);
 s32 VMC_Send_BoardInfo_SC(u8 *board_snsr_data);
+ePlatformType Vmc_Get_PlatformType(void);
 
 #endif /* INC_VMC_API_H_ */

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -237,3 +237,8 @@ static u8 Vmc_ConfigurePlatform(const char * product_name)
 
 	return status;
 }
+
+ePlatformType Vmc_Get_PlatformType(void)
+{
+	return current_platform;
+}

--- a/vmr/src/vmc/vmc_sc_comms.c
+++ b/vmr/src/vmc/vmc_sc_comms.c
@@ -406,8 +406,15 @@ s32 VMC_Fetch_BoardInfo(u8 *board_snsr_data)
 
     (void)VMC_Get_BoardInfo(&board_info);
     
-    Cl_SecureMemcpy(board_snsr_data, sizeof(Versal_BoardInfo), &board_info, sizeof(Versal_BoardInfo));
     byte_count = sizeof(Versal_BoardInfo);
+
+    /*Since VCK5000 does not support EEPROM v3, 
+     *Reducing the size of boardinfo*/
+    if(Vmc_Get_PlatformType() == eVCK5000)
+    {
+    	byte_count -= (sizeof(board_info.Num_MAC_IDS) + sizeof(board_info.capability));
+    }
+    Cl_SecureMemcpy(board_snsr_data, byte_count, &board_info, byte_count);
 
     /* Check and return -1 if size of response is > 256 */
     return ((byte_count <= MAX_VMC_SC_UART_BUF_SIZE) ? (byte_count) : (-1));


### PR DESCRIPTION
Change Log:

	- Modified Board Info payload length send to SC for VCK5000 platform.

Signed-off-by : Thirukumaran K <thirukum@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1137708

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified Board Info payload length send to SC for VCK5000 platform.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested with SC 4.4.35
**Flashable partitions running on FPGA
  Platform             : xilinx_vck5000
  SC Version           : 4.4.35
  Platform ID          : 0x0

Flashable partitions installed in system
  Platform             : xilinx_vck5000_gen4x8_qdma_base_1
  SC Version           : 4.4.35
  Platform UUID        : 936461A7-4F36-2DCB-2180-CAE3F7675096**

#### Documentation impact (if any)
NA