### PR TITLE
all VMR ERROR message is disabled by accident.

### DIFF
--- a/vmr/src/include/cl_log.h
+++ b/vmr/src/include/cl_log.h
@@ -34,10 +34,10 @@ static const char *app_type_name[] = {
 };
 
 typedef enum cl_log_level {
-	CL_LOG_LEVEL_PRNT = 0,
-	CL_LOG_LEVEL_ERR,
+	CL_LOG_LEVEL_ERR = 0, /* Please do not change log level value, ERR is using 0 as default value */
 	CL_LOG_LEVEL_LOG,
 	CL_LOG_LEVEL_DBG,
+	CL_LOG_LEVEL_PRNT, /*TODO: explain what is this level */
 } cl_log_level_t;
 
 typedef enum cl_uart_log_level {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

The previous change in cl_log level disabled all ERROR messages. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
