### PR TITLE
Bug fix while receiving override values from XRT

### DIFF
--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -317,9 +317,9 @@ int clk_scaling_handle(cl_msg_t *msg, struct xgq_cmd_sq *sq)
 	msg->clk_scaling_payload.aid = aid;
 	msg->clk_scaling_payload.scaling_en =
 			(u32)sq->clk_scaling_payload.scaling_en;
-	msg->clk_scaling_payload.scaling_en = 
+	msg->clk_scaling_payload.pwr_scaling_ovrd_limit =
 			(u32)sq->clk_scaling_payload.pwr_scaling_ovrd_limit;
-	msg->clk_scaling_payload.scaling_en = 
+	msg->clk_scaling_payload.temp_scaling_ovrd_limit =
 			(u8) sq->clk_scaling_payload.temp_scaling_ovrd_limit;
 
 	return 0;


### PR DESCRIPTION
Signed-off-by: Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Able set values properly when vmc receives a command from XRT to set threshold override values.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR#191
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested with XRT commands, Able to set the override threshold values correctly. 
#### Documentation impact (if any)
N/A