### PR TITLE
Fix for CR-1137708

### DIFF
--- a/vmr/src/vmc/platforms/v70.h
+++ b/vmr/src/vmc/platforms/v70.h
@@ -15,5 +15,6 @@ u8 V70_Init(void);
 s8 V70_Temperature_Read_Inlet(snsrRead_t *snsrData);
 s8 V70_Temperature_Read_Outlet(snsrRead_t *snsrData);
 s8 V70_Temperature_Read_Board(snsrRead_t *snsrData);
+s32 V70_VMC_Fetch_BoardInfo(u8 *board_snsr_data);
 
 #endif

--- a/vmr/src/vmc/platforms/vck5000.c
+++ b/vmr/src/vmc/platforms/vck5000.c
@@ -13,7 +13,6 @@
 #include "../vmc_main.h"
 #include "vck5000.h"
 #include "../vmc_sc_comms.h"
-#include "../vmc_update_sc.h"
 #include "../clock_throttling.h"
 
 #define NOMINAL_VOLTAGE 12000
@@ -28,6 +27,7 @@
 
 extern Vmc_Sensors_Gl_t sensor_glvr;
 extern msg_id_ptr msg_id_handler_ptr;
+extern Fetch_BoardInfo_Func fetch_boardinfo_ptr;
 
 Build_Clock_Throttling_Profile clock_throttling_vck5000;
 Clock_Throttling_Algorithm clock_throttling_std_algorithm;
@@ -106,6 +106,7 @@ u8 Vck5000_Init(void)
 
 	msg_id_handler_ptr = VCK5000_VMC_SC_Comms_Msg;
 	set_total_req_size(VCK5000_MAX_MSGID_COUNT);
+	fetch_boardinfo_ptr = &Vck5000_VMC_Fetch_BoardInfo;
 
 	/* platform specific initialization */
 	Build_clock_throttling_profile_VCK5000(&clock_throttling_vck5000);
@@ -347,5 +348,52 @@ u8 Vck5000_Vmc_Sc_Comms(void)
 	}
 
 	return XST_SUCCESS;
+}
+
+s32 Vck5000_VMC_Fetch_BoardInfo(u8 *board_snsr_data)
+{
+	Versal_BoardInfo board_info = { 0 };
+	/* byte_count will indicate the length of the response payload being generated */
+	u32 byte_count = 0;
+	u32 bufr_ptr = 0;
+
+	(void) VMC_Get_BoardInfo(&board_info);
+	Cl_SecureMemcpy(board_info.DIMM_size, (EEPROM_V2_0_DIMM_SIZE_SIZE + 1), board_info.Memory_size, (EEPROM_V2_0_DIMM_SIZE_SIZE + 1));
+
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_PRODUCT_NAME_SIZE + 1), board_info.product_name, (EEPROM_V2_0_PRODUCT_NAME_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_PRODUCT_NAME_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_BOARD_REV_SIZE + 1), board_info.board_rev, (EEPROM_V2_0_BOARD_REV_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_BOARD_REV_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_BOARD_SERIAL_SIZE + 1), board_info.board_serial, (EEPROM_V2_0_BOARD_SERIAL_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_BOARD_SERIAL_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_VERSION_SIZE + 1), board_info.eeprom_version, (EEPROM_VERSION_SIZE + 1));
+	bufr_ptr += (EEPROM_VERSION_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], 28, board_info.board_mac, 28);
+	bufr_ptr += 28;
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_BOARD_ACT_PAS_SIZE + 1), board_info.board_act_pas, (EEPROM_V2_0_BOARD_ACT_PAS_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_BOARD_ACT_PAS_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_BOARD_CONFIG_MODE_SIZE + 1), board_info.board_config_mode, (EEPROM_V2_0_BOARD_CONFIG_MODE_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_BOARD_CONFIG_MODE_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_MFG_DATE_SIZE + 1), board_info.board_mfg_date, (EEPROM_V2_0_MFG_DATE_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_MFG_DATE_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_PART_NUM_SIZE + 1), board_info.board_part_num, (EEPROM_V2_0_PART_NUM_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_PART_NUM_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_UUID_SIZE + 1), board_info.board_uuid, (EEPROM_V2_0_UUID_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_UUID_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_PCIE_INFO_SIZE + 1), board_info.board_pcie_info, (EEPROM_V2_0_PCIE_INFO_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_PCIE_INFO_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_MAX_POWER_MODE_SIZE + 1), board_info.board_max_power_mode, (EEPROM_V2_0_MAX_POWER_MODE_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_MAX_POWER_MODE_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_DIMM_SIZE_SIZE + 1), board_info.Memory_size, (EEPROM_V2_0_DIMM_SIZE_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_DIMM_SIZE_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_OEMID_SIZE + 1), board_info.OEM_ID, (EEPROM_V2_0_OEMID_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_OEMID_SIZE + 1);
+	Cl_SecureMemcpy(&board_snsr_data[bufr_ptr], (EEPROM_V2_0_DIMM_SIZE_SIZE + 1), board_info.DIMM_size, (EEPROM_V2_0_DIMM_SIZE_SIZE + 1));
+	bufr_ptr += (EEPROM_V2_0_DIMM_SIZE_SIZE + 1);
+
+	byte_count = bufr_ptr;
+
+	/* Check and return -1 if size of response is > 256 */
+	return ((byte_count <= MAX_VMC_SC_UART_BUF_SIZE) ? (byte_count) : (-1));
 }
 

--- a/vmr/src/vmc/platforms/vck5000.h
+++ b/vmr/src/vmc/platforms/vck5000.h
@@ -75,5 +75,6 @@ void max6639_monitor(void);
 void qsfp_monitor(void);
 
 u8 Vck5000_Vmc_Sc_Comms(void);
+s32 Vck5000_VMC_Fetch_BoardInfo(u8 *board_snsr_data);
 
 #endif

--- a/vmr/src/vmc/vmc_api.c
+++ b/vmr/src/vmc/vmc_api.c
@@ -54,7 +54,7 @@ EEPROM_Content_Details_t Ver_3_0_Offset_Size[eEeprom_max_Offset] =
 	{EEPROM_V3_0_UUID_OFFSET, EEPROM_V3_0_UUID_SIZE},
 	{EEPROM_V3_0_PCIE_INFO_OFFSET, EEPROM_V3_0_PCIE_INFO_SIZE},
 	{EEPROM_V3_0_MAX_POWER_MODE_OFFSET, EEPROM_V3_0_MAX_POWER_MODE_SIZE},
-	{EEPROM_V3_0_DIMM_SIZE_OFFSET, EEPROM_V3_0_DIMM_SIZE_SIZE},
+	{EEPROM_V3_0_MEM_SIZE_OFFSET, EEPROM_V3_0_MEM_SIZE_SIZE},
 	{EEPROM_V3_0_OEMID_SIZE_OFFSET, EEPROM_V3_0_OEMID_SIZE},
 	{EEPROM_V3_0_CAPABILITY_OFFSET, EEPROM_V3_0_CAPABILITY_SIZE},
 };
@@ -532,8 +532,8 @@ u8 Versal_EEPROM_ReadBoardInfo(void)
 			eeprom_offset[eEeprom_Max_Power_Mode].size);
 
 	status = Update_BoardInfo_Data(i2c_num, board_info.Memory_size,
-			eeprom_offset[eEeprom_Dimm_Size].offset,
-			eeprom_offset[eEeprom_Dimm_Size].size);
+			eeprom_offset[eEeprom_mem_Size].offset,
+			eeprom_offset[eEeprom_mem_Size].size);
 
 	status = Update_BoardInfo_Data(i2c_num, board_info.OEM_ID,
 			eeprom_offset[eEeprom_Oemid_Size].offset,

--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -162,8 +162,8 @@
 #define EEPROM_V3_0_MAX_POWER_MODE_OFFSET     	0x7200
 #define EEPROM_V3_0_MAX_POWER_MODE_SIZE       	1
 
-#define EEPROM_V3_0_DIMM_SIZE_OFFSET          	0x7300
-#define EEPROM_V3_0_DIMM_SIZE_SIZE            	4
+#define EEPROM_V3_0_MEM_SIZE_OFFSET          	0x7300
+#define EEPROM_V3_0_MEM_SIZE_SIZE            	4
 
 #define EEPROM_V3_0_OEMID_SIZE_OFFSET         	0x7700
 #define EEPROM_V3_0_OEMID_SIZE                	4
@@ -191,7 +191,7 @@ typedef enum eeprom_data_e
 	eEeprom_Uuid,
 	eEeprom_Pcie_Info,
 	eEeprom_Max_Power_Mode,
-	eEeprom_Dimm_Size,
+	eEeprom_mem_Size,
 	eEeprom_Oemid_Size,
 	eEeprom_Capability_Word,
 	eEeprom_max_Offset,
@@ -206,23 +206,23 @@ typedef struct eeprom_data_s
 
 typedef struct Versal_BoardInfo
 {
-    unsigned char product_name[17];
-    unsigned char board_rev[9];
-    unsigned char board_serial[15];
-    unsigned char eeprom_version[4];
-    unsigned char board_mac[4][7];
-    unsigned char board_act_pas[2];
-    unsigned char board_config_mode[2];
-    unsigned char board_mfg_date[4];
-    unsigned char board_part_num[10];
-    unsigned char board_uuid[17];
-    unsigned char board_pcie_info[9];
-    unsigned char board_max_power_mode[2];
-    unsigned char Memory_size[5];
-    unsigned char OEM_ID[5];
-    unsigned char DIMM_size[5];
-    unsigned char Num_MAC_IDS;
-    unsigned char capability[2];
+	u8 product_name[EEPROM_V3_0_PRODUCT_NAME_SIZE + 1];
+	u8 board_rev[EEPROM_V3_0_BOARD_REV_SIZE + 1];
+	u8 board_serial[EEPROM_V3_0_BOARD_SERIAL_SIZE + 1];
+	u8 eeprom_version[EEPROM_VERSION_SIZE + 1];
+	u8 board_mac[4][7];
+	u8 board_act_pas[EEPROM_V3_0_BOARD_ACT_PAS_SIZE + 1];
+	u8 board_config_mode[EEPROM_V3_0_BOARD_CONFIG_MODE_SIZE + 1];
+	u8 board_mfg_date[EEPROM_V3_0_MFG_DATE_SIZE + 1];
+	u8 board_part_num[EEPROM_V3_0_PART_NUM_SIZE + 1];
+	u8 board_uuid[EEPROM_V3_0_UUID_SIZE + 1];
+	u8 board_pcie_info[EEPROM_V3_0_PCIE_INFO_SIZE + 1];
+	u8 board_max_power_mode[EEPROM_V3_0_MAX_POWER_MODE_SIZE + 1];
+	u8 Memory_size[EEPROM_V3_0_MEM_SIZE_SIZE + 1];
+	u8 OEM_ID[EEPROM_V3_0_OEMID_SIZE + 1];
+	u8 DIMM_size[EEPROM_V3_0_MEM_SIZE_SIZE + 1];
+	u8 Num_MAC_IDS;
+	u8 capability[EEPROM_V3_0_CAPABILITY_SIZE + 1];
 } Versal_BoardInfo;
 
 #define 	MAX_PLATFORM_NAME_LEN (20u)

--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -20,6 +20,7 @@
 extern uart_rtos_handle_t uart_vmcsc_log;
 
 typedef u8 (*msg_id_ptr);
+typedef s32 (*Fetch_BoardInfo_Func)(u8 *);
 
 #define SOP_SIZE            (2)
 #define MESSAGE_ID_SIZE     (1)
@@ -187,5 +188,6 @@ bool vmc_get_boardInfo_status();
 void vmc_set_boardInfo_status(bool value);
 u8 get_total_req_size();
 void set_total_req_size(u8 value);
+
 
 #endif /* INC_VMC_VMC_SC_COMMS_H_ */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This patch adds a fix for board info length sent to SC based on detected platform.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1137708
#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified board info length.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Verified SC version after a hot reset.
```
---------------------------------------------------
[0000:af:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
---------------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : XFL1HO3F1VK2

Device properties
  Type                 : vck5000
  Name                 : VCK5000-PP

Flashable partitions running on FPGA
  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : 4.4.35
  Platform UUID        : FEAAC65A-8BD9-9924-548D-1F91503D9D40
  Interface UUID       : 960C41A3-0C35-1FB8-0F24-CDF0B8345066

Flashable partitions installed in system
  Platform             : xilinx_vck5000_gen4x8_qdma_base_2
  SC Version           : 4.4.35
  Platform UUID        : FEAAC65A-8BD9-9924-548D-1F91503D9D40

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE


  Mac Address          : 00:0A:35:0C:F6:58
                       : 00:0A:35:0C:F6:59
```
#### Documentation impact (if any)
NA