### PR TITLE
V70 Asdm Sensor Support

### DIFF
--- a/vmr/src/vmc/platforms/v70.c
+++ b/vmr/src/vmc/platforms/v70.c
@@ -10,9 +10,17 @@
 #include "v70.h"
 #include "cl_i2c.h"
 #include "../sensors/inc/lm75.h"
+#include "../sensors/inc/ina3221.h"
+#include "../sensors/inc/isl68221.h"
 #include "../vmc_main.h"
 #include "vmr_common.h"
 #include "../vmc_sc_comms.h"
+
+#define SLAVE_ADDRESS_LM75_0_V70  (0x48)
+#define SLAVE_ADDRESS_LM75_1_V70  (0x4A)
+
+#define SLAVE_ADDRESS_INA3221   (0x40)
+#define SLAVE_ADDRESS_ISL68221  (0x60)
 
 extern Vmc_Sensors_Gl_t sensor_glvr;
 extern msg_id_ptr msg_id_handler_ptr;
@@ -25,17 +33,87 @@ u8 V70_VMC_SC_Comms_Msg[] = {
 };
 
 #define V70_MAX_MSGID_COUNT     (sizeof(V70_VMC_SC_Comms_Msg)/sizeof(V70_VMC_SC_Comms_Msg[0]))
+#define MAX(a,b)	((a>b) ? a : b)
 
-u8 V70_Init(void)
+#define V70_NUM_BOARD_INFO_SENSORS	(11)
+#define V70_NUM_TEMPERATURE_SENSORS	(3)
+#define V70_NUM_SC_VOLTAGE_SENSORS	(2)
+#define V70_NUM_SYSMON_VOLTAGE_SENSORS	(1)
+#define V70_NUM_SC_CURRENT_SENSORS	(3)
+#define V70_NUM_POWER_SENSORS		(1)
+
+extern platform_sensors_monitor_ptr Monitor_Sensors;
+extern supported_sdr_info_ptr get_supported_sdr_info;
+extern asdm_update_record_count_ptr asdm_update_record_count;
+
+void V70_Voltage_Monitor_12V_PEX(void);
+void V70_Current_Monitor_12V_PEX(void);
+void V70_Voltage_Monitor_3v3_PEX(void);
+void V70_Current_Monitor_3v3_PEX(void);
+void V70_Voltage_Monitor_3v3_AUX(void);
+
+AsdmHeader_info_t v70_asdmHeader_info[] = {
+		{BoardInfoSDR,		V70_NUM_BOARD_INFO_SENSORS},
+		{TemperatureSDR,	V70_NUM_TEMPERATURE_SENSORS},
+		{VoltageSDR,		V70_NUM_SC_VOLTAGE_SENSORS + V70_NUM_SYSMON_VOLTAGE_SENSORS},
+		{CurrentSDR,		V70_NUM_SC_CURRENT_SENSORS},
+		{PowerSDR,		V70_NUM_POWER_SENSORS},
+};
+#define MAX_SDR_REPO 	(sizeof(v70_asdmHeader_info)/sizeof(v70_asdmHeader_info[0]))
+
+u32 V70_Supported_Sensors[] = {
+	eProduct_Name,
+	eSerial_Number,
+	ePart_Number,
+	eRevision,
+	eMfg_Date,
+	eUUID,
+	eMAC_0,
+	eFpga_Fan_1,
+	eActive_SC_Ver,
+	eTarget_SC_Ver,
+	eOEM_Id,
+
+	/* Temperature SDR */
+	eTemp_Board,
+	eTemp_Sysmon_Fpga,
+	eTemp_Vccint_Temp,
+
+	/* Voltage SDR */
+	eVoltage_Sysmon_Vccint,
+	eVoltage_12v_Pex,
+	eVoltage_3v3_Pex,
+
+	/* Current SDR */
+	eCurrent_12v_Pex,
+	eCurrent_3v3_Pex,
+	eCurrent_Vccint,
+
+
+	/* Power SDR */
+	ePower_Total
+};
+
+void V70_Get_Supported_Sdr_Info(u32 *platform_Supported_Sensors, u32 *sdr_count)
 {
-	//s8 status = XST_FAILURE;
-	msg_id_handler_ptr = V70_VMC_SC_Comms_Msg;
-	set_total_req_size(V70_MAX_MSGID_COUNT);
-	fetch_boardinfo_ptr = &V70_VMC_Fetch_BoardInfo;
+	*sdr_count = (sizeof(V70_Supported_Sensors) / sizeof(V70_Supported_Sensors[0]));
+	Cl_SecureMemcpy(platform_Supported_Sensors, sizeof(V70_Supported_Sensors),
+			V70_Supported_Sensors,sizeof(V70_Supported_Sensors));
 
-	return XST_SUCCESS;
+	return;
 }
 
+void V70_Asdm_Update_Record_Count(Asdm_Header_t *headerInfo)
+{
+	u8 i = 0;
+	for(i=0; i < MAX_SDR_REPO; i++)
+	{
+		if(headerInfo[i].repository_type == v70_asdmHeader_info[i].record_type) {
+			headerInfo[i].no_of_records = v70_asdmHeader_info[i].record_count;
+		}
+	}
+	return;
+}
 
 s8 V70_Temperature_Read_Inlet(snsrRead_t *snsrData)
 {
@@ -84,7 +162,7 @@ s8 V70_Temperature_Read_Board(snsrRead_t *snsrData)
 	s8 status = XST_SUCCESS;
 	s16 TempReading = 0;
 
-	TempReading = (sensor_glvr.sensor_readings.board_temp[0] + sensor_glvr.sensor_readings.board_temp[1])/2;
+	TempReading = MAX(sensor_glvr.sensor_readings.board_temp[0], sensor_glvr.sensor_readings.board_temp[1]);
 
 	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(TempReading),&TempReading,sizeof(TempReading));
 	snsrData->sensorValueSize = sizeof(TempReading);
@@ -93,7 +171,7 @@ s8 V70_Temperature_Read_Board(snsrRead_t *snsrData)
 	return status;
 }
 
-void LM75_monitor(void)
+void V70_Temperature_Monitor(void)
 {
 	u8 status = XST_FAILURE;
 	status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_0_V70, &sensor_glvr.sensor_readings.board_temp[0]);
@@ -108,6 +186,11 @@ void LM75_monitor(void)
 		VMC_DBG("Failed to read LM75_1 \n\r");
 	}
 
+	status =  ISL68221_ReadVCCINT_Temperature(i2c_main, SLAVE_ADDRESS_ISL68221, &sensor_glvr.sensor_readings.vccint_temp);
+	if (status == XST_FAILURE)
+	{
+		VMC_DBG("Failed to read Vccint_temp from : 0x%x", SLAVE_ADDRESS_ISL68221);
+	}
 	return;
 }
 
@@ -124,4 +207,228 @@ s32 V70_VMC_Fetch_BoardInfo(u8 *board_snsr_data)
 
     /* Check and return -1 if size of response is > 256 */
     return ((byte_count <= MAX_VMC_SC_UART_BUF_SIZE) ? (byte_count) : (-1));
+}
+
+void V70_Voltage_Monitor_12V_PEX()
+{
+	u8 status = XST_FAILURE;
+	float volatge = 0.0;
+	status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 0, &volatge);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read 12vPex voltage");
+	}
+
+	/* Divide by 1000 to convert to milli Volts */
+	sensor_glvr.sensor_readings.voltage[e12V_PEX] = (volatge/1000.0);
+}
+
+void V70_Current_Monitor_12V_PEX()
+{
+	u8 status = XST_FAILURE;
+	float current = 0.0;
+	status = INA3221_ReadCurrent(i2c_main, SLAVE_ADDRESS_INA3221, 0, &current);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read 12vPex current");
+	}
+
+	/* Divide by 1000 to convert to milli Amps */
+	sensor_glvr.sensor_readings.current[e12V_PEX] = (current/1000.0);
+}
+
+void V70_Voltage_Monitor_3v3_PEX()
+{
+	u8 status = XST_FAILURE;
+	float volatge = 0.0;
+	status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 1, &volatge);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read 3v3 pex voltage");
+	}
+	/* Divide by 1000 to convert to milli Volts */
+	sensor_glvr.sensor_readings.voltage[e3V3_PEX] = (volatge/1000.0);
+}
+
+void V70_Current_Monitor_3v3_PEX()
+{
+	u8 status = XST_FAILURE;
+	float current = 0.0;
+	status = INA3221_ReadCurrent(i2c_main, SLAVE_ADDRESS_INA3221, 1, &current);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read 3v3 Pex current");
+	}
+	/* Divide by 1000 to convert to milli Amps */
+	sensor_glvr.sensor_readings.current[e3V3_PEX] = (current/1000.0);
+}
+
+void V70_Voltage_Monitor_3v3_AUX()
+{
+	u8 status = XST_FAILURE;
+	float volatge = 0.0;
+	status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 2, &volatge);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read 3v3 Aux voltage");
+	}
+
+	/* Divide by 1000 to convert to milli Volts */
+	sensor_glvr.sensor_readings.voltage[e3V3_AUX] = (volatge/1000.0);
+}
+
+void V70_Power_Monitor()
+{
+	u8 status = XST_FAILURE;
+	float power_12v_pex = 0.0;
+	float power_3v3_pex = 0.0;
+	status = INA3221_ReadPower(i2c_main, SLAVE_ADDRESS_INA3221, 0, &power_12v_pex);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read 12v Pex power");
+	}
+
+	status = INA3221_ReadPower(i2c_main, SLAVE_ADDRESS_INA3221, 1, &power_3v3_pex);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read 3v3 Pex power");
+	}
+
+	/* Divide by 1000 to convert to Watts */
+	sensor_glvr.sensor_readings.total_power = (power_12v_pex + power_3v3_pex)/1000.0;
+}
+
+void V70_Current_Monitor_Vccint()
+{
+	u8 status = XST_SUCCESS;
+	float currentInA = 0.0;
+
+	status =  ISL68221_ReadVCCINT_Current(i2c_main, SLAVE_ADDRESS_ISL68221, &currentInA);
+	if(XST_SUCCESS != status)
+	{
+		VMC_ERR("Failed to read Vccint Current ");
+	}
+
+	sensor_glvr.sensor_readings.current[eVCCINT] = currentInA; //In Amps
+}
+
+s8 V70_Asdm_Read_Power(snsrRead_t *snsrData) {
+
+	s8 status = XST_SUCCESS;
+	u16 total_power = sensor_glvr.sensor_readings.total_power;
+
+	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(total_power),&total_power,sizeof(total_power));
+	snsrData->sensorValueSize = sizeof(total_power);
+	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+
+	return status;
+}
+
+s8 V70_Asdm_Read_Voltage_12v(snsrRead_t *snsrData) {
+
+	s8 status = XST_SUCCESS;
+	/* Multiply by 1000 to convert to Volts */
+	u16 voltage = (sensor_glvr.sensor_readings.voltage[e12V_PEX]* 1000);
+
+	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(voltage),&voltage,sizeof(voltage));
+	snsrData->sensorValueSize = sizeof(voltage);
+	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+
+	return status;
+}
+
+s8 V70_Asdm_Read_Voltage_3v3(snsrRead_t *snsrData) {
+
+	s8 status = XST_SUCCESS;
+	/* Multiply by 1000 to convert to Volts */
+	u16 voltage = (sensor_glvr.sensor_readings.voltage[e3V3_PEX]* 1000);
+
+	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(voltage),&voltage,sizeof(voltage));
+	snsrData->sensorValueSize = sizeof(voltage);
+	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+
+	return status;
+}
+
+s8 V70_Asdm_Read_Current_12v(snsrRead_t *snsrData) {
+
+	s8 status = XST_SUCCESS;
+	u16 current = (sensor_glvr.sensor_readings.current[e12V_PEX]* 1000);
+
+	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
+	snsrData->sensorValueSize = sizeof(current);
+	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+
+	return status;
+}
+
+s8 V70_Asdm_Read_Current_3v3(snsrRead_t *snsrData) {
+
+	s8 status = XST_SUCCESS;
+	u16 current = (sensor_glvr.sensor_readings.current[e3V3_PEX] * 1000);
+
+	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
+	snsrData->sensorValueSize = sizeof(current);
+	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+
+	return status;
+}
+
+s8 V70_Asdm_Read_Current_Vccint(snsrRead_t *snsrData)
+{
+	s8 status = XST_SUCCESS;
+	u16 current = (sensor_glvr.sensor_readings.current[eVCCINT] * 1000);
+
+	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
+	snsrData->sensorValueSize = sizeof(current);
+	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+
+	return status;
+}
+
+s8 V70_Asdm_Read_Temp_Vccint(snsrRead_t *snsrData)
+{
+	s8 status = XST_SUCCESS;
+	u16 temp = (sensor_glvr.sensor_readings.vccint_temp);
+
+	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(temp),&temp,sizeof(temp));
+	snsrData->sensorValueSize = sizeof(temp);
+	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+
+	return status;
+}
+
+void V70_Monitor_Sensors()
+{
+//	snsrRead_t *snsrData = NULL;
+
+	/* Read Temp Sensors */
+//	V70_Temperature_Read_Inlet(snsrData);
+//	V70_Temperature_Read_Outlet(snsrData);
+	V70_Temperature_Monitor();
+
+	/* Read Voltage Sensors */
+	V70_Voltage_Monitor_12V_PEX();
+	V70_Voltage_Monitor_3v3_PEX();
+	V70_Voltage_Monitor_3v3_AUX();
+
+	/* Read Current Sensors */
+	V70_Current_Monitor_12V_PEX();
+	V70_Current_Monitor_3v3_PEX();
+	V70_Current_Monitor_Vccint();
+
+	/* Read Power Sensors */
+	V70_Power_Monitor();
+}
+
+u8 V70_Init(void)
+{
+	//s8 status = XST_FAILURE;
+	msg_id_handler_ptr = V70_VMC_SC_Comms_Msg;
+	set_total_req_size(V70_MAX_MSGID_COUNT);
+	Monitor_Sensors = V70_Monitor_Sensors;
+
+	get_supported_sdr_info = V70_Get_Supported_Sdr_Info;
+	asdm_update_record_count = V70_Asdm_Update_Record_Count;
+	return XST_SUCCESS;
 }

--- a/vmr/src/vmc/platforms/v70.h
+++ b/vmr/src/vmc/platforms/v70.h
@@ -8,13 +8,11 @@
 
 #include "../vmc_asdm.h"
 
-#define SLAVE_ADDRESS_LM75_0_V70  (0x48)
-#define SLAVE_ADDRESS_LM75_1_V70  (0x4A)
-
 u8 V70_Init(void);
 s8 V70_Temperature_Read_Inlet(snsrRead_t *snsrData);
 s8 V70_Temperature_Read_Outlet(snsrRead_t *snsrData);
 s8 V70_Temperature_Read_Board(snsrRead_t *snsrData);
 s32 V70_VMC_Fetch_BoardInfo(u8 *board_snsr_data);
+s8 V70_Asdm_Read_Power(snsrRead_t *snsrData);
 
 #endif

--- a/vmr/src/vmc/platforms/vck5000.h
+++ b/vmr/src/vmc/platforms/vck5000.h
@@ -69,6 +69,7 @@ s8 Vck5000_Temperature_Read_Outlet(snsrRead_t *snsrData);
 s8 Vck5000_Temperature_Read_Board(snsrRead_t *snsrData);
 s8 Vck5000_Temperature_Read_QSFP(snsrRead_t *snsrData);
 s8 Vck5000_Fan_RPM_Read(snsrRead_t *snsrData);
+s8 Vck5000_Asdm_Read_Power(snsrRead_t *snsrData);
 
 void se98a_monitor(void);
 void max6639_monitor(void);

--- a/vmr/src/vmc/sensors/inc/isl68221.h
+++ b/vmr/src/vmc/sensors/inc/isl68221.h
@@ -1,0 +1,28 @@
+
+/******************************************************************************
+ * * Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+ * * SPDX-License-Identifier: MIT
+ * *******************************************************************************/
+
+#ifndef INCLUDE_ISL68221_H
+#define INCLUDE_ISL68221_H
+
+#include "xil_types.h"
+
+#define ISL68221_PAGE_REGISTER                    0x00
+
+#define ISL68221_SELECT_PAGE_VCCINT               0x00
+#define ISL68221_SELECT_PAGE_1v2_VCCO             0x01
+
+#define ISL68221_OUTPUT_VOLTAGE_REGISTER          0x8B
+#define ISL68221_OUTPUT_CURRENT_REGISTER          0x8C
+#define ISL68221_READ_POWERSTAGE_TEMPERATURE      0x8D
+
+u8 ISL68221_write_register(u8 i2c_num, u8 SlaveAddr, u8 register_address, u8 *register_content);
+u8 ISL68221_read_register(u8 i2c_num, u8 SlaveAddr, u8 register_address, u8 *register_content);
+
+u8 ISL68221_ReadVCCINT_Voltage(u8 busnum, u8 slaveAddr, float *voltageInmV);
+u8 ISL68221_ReadVCCINT_Current(u8 busnum, u8 slaveAddr, float *currentInA);
+u8 ISL68221_ReadVCCINT_Temperature(u8 busnum, u8 slaveAddr, float *temperature);
+
+#endif

--- a/vmr/src/vmc/sensors/src/ina3221.c
+++ b/vmr/src/vmc/sensors/src/ina3221.c
@@ -6,13 +6,14 @@
 #include "cl_i2c.h"
 #include "../inc/ina3221.h"
 
+#define SHUNT_RESISTANCE_VALUE (0.002)
 
 u8 INA3221_ReadVoltage(u8 busnum, u8 slaveAddr, u8 channelNum, float *voltageInmV)
 {
-    u8 wbuf[8];
-    u8 rbuf[8];
-    u8 status;
-    u16 rddata;
+    u8 wbuf[8] = {0};
+    u8 rbuf[8] = {0};
+    u8 status = 0;
+    u16 rddata = 0;
 
     wbuf[0] = INA3221_CH1_BUS_VOLTAGE;                
 
@@ -24,8 +25,9 @@ u8 INA3221_ReadVoltage(u8 busnum, u8 slaveAddr, u8 channelNum, float *voltageInm
     status = i2c_send_rs_recv(busnum, slaveAddr, (u8 *)wbuf, 1, (u8 *)&rbuf[0], 2);
     if (0 == status)
     {
+    	rbuf[1] = rbuf[1] & ~0x7;
         rddata = ((u16)rbuf[1]) | ((u16)rbuf[0] << 8);
-        rddata &= ~0x7;                             
+//        rddata &= ~0x7;
         *voltageInmV = ((float) rddata);
     }
     return status;
@@ -33,10 +35,10 @@ u8 INA3221_ReadVoltage(u8 busnum, u8 slaveAddr, u8 channelNum, float *voltageInm
 }
 u8 INA3221_ReadCurrent(u8 busnum, u8 slaveAddr, u8 channelNum, float *currentInmA)
 {
-    uint8_t wbuf[8];
-    uint8_t rbuf[8];
-    uint8_t status;
-    uint16_t rddata;
+    u8 wbuf[8] = {0};
+    u8 rbuf[8] = {0};
+    u8 status = 0;
+    u16 rddata = 0;
 
     wbuf[0] = INA3221_CH1_SHUNT_VOLTAGE;                
      if (channelNum == 1)
@@ -47,23 +49,24 @@ u8 INA3221_ReadCurrent(u8 busnum, u8 slaveAddr, u8 channelNum, float *currentInm
     status = i2c_send_rs_recv(busnum, slaveAddr, (u8 *)wbuf, 1, (u8 *)&rbuf[0], 2);
     if (0 == status)
     {
+    	rbuf[1] = rbuf[1] & ~0x7;
         rddata = ((u16) rbuf[1]) | ((u16)rbuf[0] << 8);
-        rddata &= ~0x7;                   
+        //rddata &= ~0x7;
 
         float shuntVolt = (float) (rddata >> 3);
-        shuntVolt *= (float) .00004;            
+        shuntVolt *= (float) 0.00004;
         shuntVolt *= 1000;
 
-        *currentInmA = shuntVolt / (float) .005;
+        *currentInmA = shuntVolt / (float) SHUNT_RESISTANCE_VALUE;
 
      }
     return status;
 }
 u8 INA3221_ReadPower(u8 busnum, u8 slaveAddr, u8 channelNum, float *powerInmW)
 {
-    u8 status;
-    float currentInMA;
-    float voltageInMV;
+    u8 status = 0;
+    float currentInMA = 0.0;
+    float voltageInMV = 0.0;
 
     if ( (status = INA3221_ReadCurrent(busnum,slaveAddr,channelNum,&currentInMA)) == 0)
     {

--- a/vmr/src/vmc/sensors/src/isl68221.c
+++ b/vmr/src/vmc/sensors/src/isl68221.c
@@ -1,0 +1,103 @@
+/******************************************************************************
+ *  * * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ *   * * SPDX-License-Identifier: MIT
+ *    * *******************************************************************************/
+
+#include "cl_i2c.h"
+#include "../inc/isl68221.h"
+
+#define STATUS_FAILURE		(1)
+u8 ISL68221_write_register(u8 i2c_num, u8 SlaveAddr, u8 register_address, u8 *register_content)
+{
+    u8 status = 0;
+
+    u8 write_data[2]= {0};
+    write_data[0] = register_address;
+    write_data[1] = *register_content;
+    status = i2c_send(i2c_num, SlaveAddr, write_data, 2);
+
+    return status;
+}
+u8 ISL68221_read_register(u8 i2c_num, u8 SlaveAddr, u8 register_address, u8 *register_content)
+{
+    u8 status = 0;
+
+    status = i2c_send_rs_recv(i2c_num, SlaveAddr, &register_address,1, register_content, 2);
+
+    return status;
+}
+u8 ISL68221_ReadVCCINT_Voltage(u8 busnum, u8 slaveAddr, float *voltageInmV)
+{
+    u8 wbuf[8] = {0};
+    u8 rbuf[8]= {0};
+    u8 status = 0;
+    u16 rddata = 0;
+
+    wbuf[0] = ISL68221_SELECT_PAGE_VCCINT;
+
+    status = ISL68221_write_register(busnum, slaveAddr, ISL68221_PAGE_REGISTER,(u8 *)wbuf);
+    if (STATUS_FAILURE == status)
+    {
+    	return status;
+    }
+
+    status = ISL68221_read_register(busnum, slaveAddr, ISL68221_OUTPUT_VOLTAGE_REGISTER,(u8 *)&rbuf[0]);
+    if (STATUS_FAILURE == status)
+    {
+    	return status;
+    }
+    rddata = (rbuf[1] << 8) | rbuf[0];
+    *voltageInmV = ((float) rddata);
+    return status;
+
+}
+u8 ISL68221_ReadVCCINT_Current(u8 busnum, u8 slaveAddr, float *currentInA)
+{
+    u8 wbuf[8] = {0};
+    u8 rbuf[8] = {0};
+    u8 status = 0;
+    u16 rddata = 0;
+
+    wbuf[0] = ISL68221_SELECT_PAGE_VCCINT;
+
+    status = ISL68221_write_register(busnum, slaveAddr, ISL68221_PAGE_REGISTER,(u8 *)wbuf);
+    if (STATUS_FAILURE == status)
+    {
+    	return status;
+    }
+
+    status = ISL68221_read_register(busnum, slaveAddr, ISL68221_OUTPUT_CURRENT_REGISTER,(u8 *)&rbuf[0]);
+    if (STATUS_FAILURE == status)
+    {
+    	return status;
+    }
+    rddata = (rbuf[1] << 8) | rbuf[0];
+    *currentInA = ((float) rddata)/10;
+    return status;
+
+}
+u8 ISL68221_ReadVCCINT_Temperature(u8 busnum, u8 slaveAddr, float *temperature)
+{
+    u8 wbuf[8] = {0};
+    u8 rbuf[8] = {0};
+    u8 status = 0;
+    u16 rddata = 0;
+
+    wbuf[0] = ISL68221_SELECT_PAGE_VCCINT;
+
+    status = ISL68221_write_register(busnum, slaveAddr, ISL68221_PAGE_REGISTER,(u8 *)wbuf);
+    if (STATUS_FAILURE == status)
+    {
+    	return status;
+    }
+
+    status = ISL68221_read_register(busnum, slaveAddr, ISL68221_READ_POWERSTAGE_TEMPERATURE,(u8 *)&rbuf[0]);
+    if (STATUS_FAILURE == status)
+    {
+    	return status;
+    }
+    rddata = (rbuf[1] << 8) | rbuf[0];
+    *temperature = ((float) rddata);
+    return status;
+
+}

--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -244,7 +244,7 @@ typedef enum{
 	eTemperature_Sensor_Outlet,
 	eTemperature_Sensor_Board,
 	eTemperature_Sensor_QSFP,
-	//eFAN_RPM_READ,
+	ePower_Sensor,
 	eMax_Sensor_Functions,
 } eSensor_Functions;
 
@@ -391,9 +391,12 @@ extern sensorMonitorFunc Temperature_Read_Inlet_Ptr;
 extern sensorMonitorFunc Temperature_Read_Outlet_Ptr;
 extern sensorMonitorFunc Temperature_Read_Board_Ptr;
 extern sensorMonitorFunc Temperature_Read_QSFP_Ptr;
-//extern sensorMonitorFunc Fan_RPM_Read_Ptr;
+extern sensorMonitorFunc Power_Read_Ptr;
 
 void VMC_Get_BoardInfo(Versal_BoardInfo *ptr);
 s32 VMC_Send_BoardInfo_SC(u8 *board_snsr_data);
+
+typedef void (*platform_sensors_monitor_ptr)(void);
+typedef void (*supported_sdr_info_ptr) (u32 *supported_pdr, u32 *pdr_count);
 
 #endif /* INC_VMC_API_H_ */

--- a/vmr/src/vmc/vmc_asdm.h
+++ b/vmr/src/vmc/vmc_asdm.h
@@ -37,6 +37,47 @@ typedef enum Asdm_Repository_Type_Enum_e
     VMCLogDataSDR  = 0xE1,
 }Asdm_RepositoryTypeEnum_t;
 
+typedef enum
+{
+	eProduct_Name,
+	eSerial_Number,
+	ePart_Number,
+	eRevision,
+	eMfg_Date,
+	eUUID,
+	eMAC_0,
+	eMAC_1,
+	eFpga_Fan_1,
+	eActive_SC_Ver,
+	eTarget_SC_Ver,
+	eOEM_Id,
+
+	/* Temperature SDR */
+	eTemp_Board,
+	eTemp_Sysmon_Fpga,
+	eTemp_Vccint,
+	eTemp_Qsfp,
+	eTemp_Vccint_Temp,
+
+	/* Voltage SDR */
+	eVolatge_SC_Sensors,
+	eVoltage_Sysmon_Vccint,
+	eVoltage_12v_Pex,
+	eVoltage_3v3_Pex,
+
+	/* Current SDR */
+	eCurrent_SC_Sensors,
+	eCurrent_SC_Vccint,
+	eCurrent_12v_Pex,
+	eCurrent_3v3_Pex,
+	eCurrent_Vccint,
+
+	/* Power SDR */
+	ePower_Total,
+
+	eSdr_Sensor_Max
+}Asdm_Sensor_PDR_List_t;
+
 typedef enum Threshold_Support_Enum
 {
     Upper_Warning_Threshold  = 0x01,
@@ -197,9 +238,16 @@ typedef enum Sensor_Status_Enum_e
     Sensor_Status_Not_Available = 0x7F,
 }SDR_Sensor_Status_Enum_t;
 
+typedef struct __attribute__((packed)) {
+	Asdm_RepositoryTypeEnum_t record_type;
+	u8 record_count;
+}AsdmHeader_info_t;
+
 s8 Init_Asdm();
-void Monitor_Sensors(void);
+void Asdm_Update_Sensors(void);
 s8 Asdm_Process_Sensor_Request(u8 *req, u8 *resp, u16 *respSize);
+
+typedef void (*asdm_update_record_count_ptr) (Asdm_Header_t *headerInfo );
 
 #endif
 

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -46,10 +46,12 @@ Platform_Sensor_Handler_t platform_sensor_handlers[]=
 	{eVCK5000,eTemperature_Sensor_Outlet,Vck5000_Temperature_Read_Outlet},
 	{eVCK5000,eTemperature_Sensor_Board,Vck5000_Temperature_Read_Board},
 	{eVCK5000,eTemperature_Sensor_QSFP,Vck5000_Temperature_Read_QSFP},
+	{eVCK5000,ePower_Sensor,Vck5000_Asdm_Read_Power},
 	{eV70,eTemperature_Sensor_Inlet,V70_Temperature_Read_Inlet},
 	{eV70,eTemperature_Sensor_Outlet,V70_Temperature_Read_Outlet},
 	{eV70,eTemperature_Sensor_Board,V70_Temperature_Read_Board},
 	{eV70, eTemperature_Sensor_QSFP, NULL},
+	{eV70,ePower_Sensor,V70_Asdm_Read_Power},
 };
 
 Platform_Function_Handler_t platform_function_handlers[]=
@@ -227,9 +229,9 @@ static u8 Vmc_ConfigurePlatform(const char * product_name)
 				Temperature_Read_QSFP_Ptr = Vmc_Find_Sensor_Handler(i);
 				break;
 
-//			case eFAN_RPM_READ:
-//				Fan_RPM_Read_Ptr = Vmc_Find_Sensor_Handler(i);
-//				break;
+			case ePower_Sensor:
+				Power_Read_Ptr = Vmc_Find_Sensor_Handler(i);
+				break;
 
 		}
 	}

--- a/vmr/src/vmc/vmc_sensors.h
+++ b/vmr/src/vmc/vmc_sensors.h
@@ -14,14 +14,26 @@
 #define POWER_MODE_300W 3
 #define LPD_I2C_0	0x1
 
+typedef enum {
+	e12V_PEX = 0,
+	e3V3_PEX,
+	e3V3_AUX,
+	eVCCINT,
+	eElectrical_Sensor_Max,
+}eElectrical_sensors_t;
+
 typedef struct
 {
 	s16 board_temp[BOARD_TEMPERATURE_SENSOR_NUM];
 	float local_temp;
 	float remote_temp;
 	float sysmon_max_temp;
+	float vccint_temp;
 	float qsfp_temp[QSFP_TEMPERATURE_SENSOR_NUM];
 	u16 fanRpm;
+	float voltage[eElectrical_Sensor_Max];
+	float current[eElectrical_Sensor_Max];
+	float total_power;
 
 } Versal_sensor_readings;
 


### PR DESCRIPTION
- Add Sensor support for V70.
- Enable Sensor reporting over ASDM.

Signed-off-by: Sandeep Kumar Thakur <sandeep.thakur@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This commit Enables reporting all Sensor for V70 over XRT 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/VITIS-5879,

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Sensor reading was read continuously in a loop for over 2 hours with no failure observed, for both VCK5K and V70
```
-----------------------------------------------
[0000:29:00.1] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Electrical
  Max Power              : NA Watts
  Power                  : 14 Watts
  Power Warning          : NA

  Power Rails            : Voltage   Current
  vccint                 :  0.699 V,  2.100 A
  12v_pex                : 12.024 V,  0.999 A
  3v3_pex                :  3.376 V,  0.620 A

Thermals
  Temperature            : Celcius
  PCB                    :     48 C
  device                 :     55 C
  vccint                 :     52 C
```
#### Documentation impact (if any)
NA 