### PR TITLE
XGQ reduce poll delay

### DIFF
--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -530,7 +530,7 @@ int cl_xgq_receive_init(void)
 
 void cl_xgq_receive_func(void *task_args)
 {
-	const TickType_t xBlockTime = pdMS_TO_TICKS(500);
+	const TickType_t xBlockTime = pdMS_TO_TICKS(100);
 
 	for( ;; ) {
 		uint64_t sq_slot_addr;


### PR DESCRIPTION
Reduce the XGQ poll delay to 100 from 500, to shorten the delay
observed in XRT command response.

Signed-off-by: Sandeep Kumar Thakur <sandeep.thakur@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The Response time for any XRT command reduces .

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1131057

#### How problem was solved, alternative solutions (if any) and why they were rejected
Although it does not reduce down the response time to as expected on legacy platform but has a improvement from the current state.

#### Risks (if any) associated the changes in the commit
Nothing as of today.

#### What has been tested and how, request additional testing if necessary
Test performed was sensor read in a loop and 4-5 hours of vmr.sh 

#### Documentation impact (if any)
NA