### PR TITLE
Send boardinfo to SC

### DIFF
--- a/vmr/src/vmc/platforms/v70.c
+++ b/vmr/src/vmc/platforms/v70.c
@@ -426,6 +426,8 @@ u8 V70_Init(void)
 	//s8 status = XST_FAILURE;
 	msg_id_handler_ptr = V70_VMC_SC_Comms_Msg;
 	set_total_req_size(V70_MAX_MSGID_COUNT);
+	fetch_boardinfo_ptr = &V70_VMC_Fetch_BoardInfo;
+	
 	Monitor_Sensors = V70_Monitor_Sensors;
 
 	get_supported_sdr_info = V70_Get_Supported_Sdr_Info;


### PR DESCRIPTION
Send BoardInfo data read from EEPROM to SC

Signed-off-by: Sandeep Kumar Thakur<sandeep.thakur@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1138837](https://jira.xilinx.com/browse/CR-1138837)

#### How problem was solved, alternative solutions (if any) and why they were rejected
Send BoardInfo data from VMC to SC over uart.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested on V70

```

------------------------------------------------
Product Name   : Alveo V70 ES1
Board Rev      : A01
Board Serial   : 51171A125Q0D
MAC ID Number  : 1
Board MAC0     : ff:ff:ff:ff:ff:ff
Board MAC1     : 00:00:00:00:00:00
EEPROM Version : 3.0
Board A/P      : P
Board Config   : 07
PCIe Info      : 10ee, 507c, 10ee, 000e
UUID           : 499cee63-d695-b746-b1b4-b640e9f98100
Memory Size    : 2G
MFG DATE       : b854d4
PART NUM       : 005117-01
OEM ID         : 000012a1
Capability     : 0000
FW Ver         : 8.5.1
BSL vendor ver : 0100
BSL CI ver     : 0400
BSL API ver    : 0800
BSL PI ver     : 0600
BSL build ID   : 0019
------------------------------------------------
```
#### Documentation impact (if any)
NA