### PR TITLE
print logs before onfigASSERT can stop entire VMR

### DIFF
--- a/vmr/src/include/cl_log.h
+++ b/vmr/src/include/cl_log.h
@@ -64,6 +64,7 @@ void cl_log_dump();
 void cl_uart_printf(const char *name, uint32_t line, uint8_t log_level,
 	const char *app_name, const char *fmt, ...);
 
+void cl_log_init();
 
 #define CL_PRINT(level, app_name, fmt, arg...) \
 	cl_printf(__FUNCTION__, __LINE__, level, app_name, fmt, ##arg)
@@ -103,8 +104,15 @@ void cl_uart_printf(const char *name, uint32_t line, uint8_t log_level,
 #define VMR_DBG(fmt, arg...) \
         CL_DBG(APP_VMR, fmt, ##arg)
 #define VMR_PRNT(fmt, arg...) \
-        CL_PRNT(APP_VMR, fmt, ##arg)
+        CL_ERR(APP_VMR, fmt, ##arg)
 
-void cl_log_init();
+#define VMR_ASSERT(assert, fmt, arg...) 	\
+({						\
+	if (!(assert)) {			\
+		VMR_ERR(fmt, ##arg);		\
+		configASSERT(assert);		\
+	}					\
+})
+
 
 #endif

--- a/vmr/src/vmc/vmc_sc_comms.c
+++ b/vmr/src/vmc/vmc_sc_comms.c
@@ -389,7 +389,9 @@ void VMC_RX_UART_packet(u8 Expected_Msg_Length)
 
 	if(UART_RTOS_Receive(&uart_vmcsc_log, data, Expected_Msg_Length, &receivedcount, RCV_TIMEOUT_MS(500)) == UART_SUCCESS)
 	{
-		configASSERT(receivedcount <= MAX_VMC_SC_UART_BUF_SIZE);
+		VMR_ASSERT(receivedcount <= MAX_VMC_SC_UART_BUF_SIZE,
+			"fatal error: receivedcount %d > MAX BUF SIZE %d",
+			receivedcount, MAX_VMC_SC_UART_BUF_SIZE);
 		if (receivedcount > 2) { /* Condition to avoid over bound */
 			if (VMC_Validate_SC_Packet(&data[0], receivedcount)) {
 				Cl_SecureMemcpy(g_scData, receivedcount, data, receivedcount);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
I checked all configASSERT in our code base.
The configASSERT will make sure system stop before the damage ongoing. Usually, we assert some locks cannot be NULL and protect memory corrupted by wrong memory copy.

But there is one line that can stop the VMR due to a unhealthy UART return value.
Even though, it is not expected, but stopping the entire VMR seems too agressive.
Hense, change it to VMR_ERR and return.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on V70, without this fix, sometimes the V70 VMR will be stopped due to unrecognized UART message.

#### Documentation impact (if any)
N/A