### PR TITLE
CR-1139694 load system.dtb only at the time when shell just starts

### DIFF
--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -1013,6 +1013,8 @@ int cl_rmgmt_init( void )
 {	
 	int ret = 0;
 	cl_msg_t msg = { 0 };
+	u32 dtb_offset = 0;
+	u32 dtb_size = 0;
 
 	ret = ospi_flash_init();
 	if (ret != XST_SUCCESS) {
@@ -1033,6 +1035,13 @@ int cl_rmgmt_init( void )
 
 	/* enforce next boot to default image */
 	rmgmt_enable_boot_default(&msg);
+
+	/* copy systemdtb to correct location */
+	if (rmgmt_fpt_get_systemdtb(&msg, &dtb_offset, &dtb_size) == 0) {
+		VMR_WARN("copy system.dtb off 0x%x size 0x%x to 0x%x",
+			dtb_offset, dtb_size, VMR_EP_SYSTEM_DTB);
+		cl_memcpy(VMR_EP_SYSTEM_DTB, dtb_offset, dtb_size);
+	}
 
 	rmgmt_is_ready = true;
 	VMR_LOG("Done. set rmgmt is ready.");

--- a/vmr/src/rmgmt/rmgmt_xfer.c
+++ b/vmr/src/rmgmt/rmgmt_xfer.c
@@ -384,11 +384,15 @@ static int rmgmt_ospi_apu_download(struct rmgmt_handler *rh, u32 len)
 		return 0;
 	}
 
+	/*
+	 * The systemdtb has been loaded when shell starts.
+	 * We just to verify if there is valid systemdtb before loading
+	 * apu pdi.
+	 */
 	if (rmgmt_fpt_get_systemdtb(&msg, &dtb_offset, &dtb_size)) {
 		VMR_ERR("get system.dtb failed");
 		return -1;
 	}
-	cl_memcpy(VMR_EP_SYSTEM_DTB, dtb_offset, dtb_size);
 
 	ret = rmgmt_xclbin_section_info(axlf, PDI, &offset, &size);
 	if (ret) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We should load the system.dtb when rmgmt is started.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1139694
#### How problem was solved, alternative solutions (if any) and why they were rejected
this will give xsdb debugger an chance to upload their own system.dtb before load apu pdi.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested on V70

#### Documentation impact (if any)
N/A