### PR TITLE
CR-1139862 v70 and vck5000 divergence in original system.dts

### DIFF
--- a/build/dts/v70_2022.2.dtsi
+++ b/build/dts/v70_2022.2.dtsi
@@ -106,8 +106,11 @@
     status = "disabled";
 };
 &memoryblp_axi_noc_mc_1x {
-    reg = <0x0 0x0 0x0 0x35ff0000 0x500 0x80000000 0x0 0x80000000>;
+    /delete-property/ reg;
+    reg = <0x0 0x0 0x0 0x35ff0000>;
 };
+/delete-node/ &memoryblp_axi_noc_mc_2x;
+
 / {
     chosen {
         bootargs = "console=ttyUL0  earlycon=uartlite_a,0x402020000,115200n8 clk_ignore_unused root=/dev/mmcblk0p2 rw rootwait";
@@ -115,9 +118,13 @@
     };
 
     aliases {
+	/delete-property/ serial0;
+	/delete-property/ serial1;
+	/delete-property/ serial2;
 	/delete-property/ serial3;
 	/delete-property/ serial4;
 	/delete-property/ serial5;
+	serial0 = &blp_blp_logic_axi_uart_apu;
     };
 
     reserved-memory {
@@ -138,6 +145,21 @@
         r2a_xgq_region: buffer@37000000 {
             no-map;
             reg = <0x0 0x37000000 0x0 0x1000000>;
+        };
+
+        buffer@50080000000 {
+            no-map;
+            reg = <0x500 0x80000000 0x0 0x80000000>;
+        };
+
+        buffer@50100000000 {
+            no-map;
+            reg = <0x501 0x0 0x1 0x0>;
+        };
+
+        buffer@60000000000 {
+            no-map;
+            reg = <0x600 0x0 0x02 0x0>;
         };
     };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1139862](https://jira.xilinx.com/browse/CR-1139862)
v70 and vck5000 divergence in original system.dts

#### How problem was solved, alternative solutions (if any) and why they were rejected
fix the missing config in v70.dtsi

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested with latest v70 shell manually and also with shell built by platform team.

#### Documentation impact (if any)
