### PR TITLE
CR-1140790 - VMR Implementation of Identify Command

### DIFF
--- a/vmr/src/common/cl_xgq_opcode.c
+++ b/vmr/src/common/cl_xgq_opcode.c
@@ -44,6 +44,14 @@ static int opcode_vmc_clk_throttling(cl_msg_t *msg)
 	return cl_vmc_clk_scaling(msg);
 }
 
+static int opcode_vmr_identify(cl_msg_t *msg)
+{
+	//Assuming 0 on a successful event and only one response type for this Command; so cl_vmr_identify() is not defined.
+	msg->hdr.version_major = VMR_IDENTIFY_CMD_MAJOR;
+	msg->hdr.version_minor = VMR_IDENTIFY_CMD_MINOR;
+	return 0;
+}
+
 struct opcode_handle {
 	const char 	*msg_type_name;
 	cl_msg_type_t	msg_type;
@@ -54,6 +62,7 @@ struct opcode_handle {
 	{"VMR CONTROL", CL_MSG_VMR_CONTROL, opcode_vmr_control},
 	{"SENSOR", CL_MSG_SENSOR, opcode_vmc_sensor},
 	{"CLOCK THROTTLING", CL_MSG_CLK_THROTTLING, opcode_vmc_clk_throttling},
+	{"VMR IDENTIFY CMD", CL_MSG_VMR_IDENTIFY, opcode_vmr_identify},
 };
 
 static void process_program_msg(cl_msg_t *msg)

--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -155,6 +155,9 @@ void cl_msg_handle_complete(cl_msg_t *msg)
 					scaling_params.limits.throttle_limit_pwr;
 
 
+	} else if (msg->hdr.type == CL_MSG_VMR_IDENTIFY){
+		cmd_cq->cq_vmr_identify_payload.ver_major = msg->hdr.version_major;
+		cmd_cq->cq_vmr_identify_payload.ver_minor = msg->hdr.version_minor;
 	}
 
 	if (xSemaphoreTake(msg_complete_lock, portMAX_DELAY)) {
@@ -343,6 +346,8 @@ static struct xgq_cmd_handler xgq_cmd_handlers[] = {
 	{XGQ_CMD_OP_SENSOR, CL_MSG_SENSOR, "SENSOR", sensor_handle, CL_QUEUE_OPCODE},
 	{XGQ_CMD_OP_PROGRAM_SCFW, CL_MSG_PROGRAM_SCFW, "PROGRAM SCFW", NULL, CL_QUEUE_PROGRAM},
 	{XGQ_CMD_OP_CLOCK_THROTTLING, CL_MSG_CLK_THROTTLING, "CLOCK THROTTLING", clk_scaling_handle, CL_QUEUE_OPCODE},
+	{XGQ_CMD_OP_IDENTIFY, CL_MSG_VMR_IDENTIFY, "VMR IDENTIFY", NULL, CL_QUEUE_OPCODE},
+
 };
 
 /*

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -14,6 +14,10 @@
 /* The Clock IP use index 0 for data, 1 for kernel, 2 for sys, 3 for sys1 */ 
 #define XGQ_CLOCK_WIZ_MAX_RES           4
 
+/* VMR Identify Command Version Major and Minor Numbers */
+#define VMR_IDENTIFY_CMD_MAJOR			1
+#define VMR_IDENTIFY_CMD_MINOR			0
+
 /**
  * sensor data request types
  */
@@ -327,6 +331,18 @@ struct xgq_cmd_cq_clk_scaling_payload {
     uint16_t pwr_shutdown_limit;
     uint16_t pwr_scaling_limit;
 };
+
+/*
+ * struct xgq_cmd_cq_vmr_identify_payload: Identify Command payload
+ *
+ * VMR Identify Command
+*/
+struct xgq_cmd_cq_vmr_identify_payload {
+    uint16_t ver_major;
+    uint16_t ver_minor;
+    uint32_t resvd;
+};
+
 /*
  * struct xgq_cmd_cq: vmr completion command
  *
@@ -350,6 +366,7 @@ struct xgq_cmd_cq {
 		struct xgq_cmd_cq_log_page_payload	cq_log_payload;
 		struct xgq_cmd_cq_data_payload		cq_xclbin_payload;
 		struct xgq_cmd_cq_clk_scaling_payload	cq_clk_scaling_payload;
+		struct xgq_cmd_cq_vmr_identify_payload  cq_vmr_identify_payload;
 	};
 	uint32_t rcode;
 };

--- a/vmr/src/include/cl_msg.h
+++ b/vmr/src/include/cl_msg.h
@@ -17,6 +17,7 @@ typedef enum cl_msg_type {
 	CL_MSG_VMR_CONTROL,
 	CL_MSG_PROGRAM_SCFW,
 	CL_MSG_CLK_THROTTLING,
+	CL_MSG_VMR_IDENTIFY,
 } cl_msg_type_t;
 
 typedef enum cl_sensor_type {
@@ -154,10 +155,10 @@ struct xgq_vmr_clk_scaling_payload {
 };
 
 struct xgq_vmr_head {
-	u16 version;
+	u16 version_major;
+	u16 version_minor;
 	u16 type;
 	u16 cid;
-	u16 pad;
 	u32 rcode;
 };
 
@@ -175,6 +176,7 @@ typedef struct cl_msg {
 		struct xgq_vmr_clock_payload clock_payload;
 		struct xgq_vmr_sensor_payload sensor_payload;
 		struct xgq_vmr_clk_scaling_payload clk_scaling_payload;
+		struct xgq_vmr_head vmr_identify_payload;
 	};
 	union {
 		struct xgq_vmr_multiboot_payload multiboot_payload;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added Command Implementation in VMR

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1140790

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Testing includes observations from Dmesg when xqg driver is loaded.
The version printed is found to be major.minor = 1.0 which is the expected response from VMR.
![VMR Identify OP](https://user-images.githubusercontent.com/111782805/192069775-c7ce4dbc-37dd-4b35-a33d-04b8e2759d94.PNG)


#### Documentation impact (if any)
NA