### PR TITLE
CR 1142095 VMR Run Time Stats CPU %

### DIFF
--- a/build/create_bsp.tcl
+++ b/build/create_bsp.tcl
@@ -30,6 +30,7 @@ bsp setlib xilmailbox
 bsp getlibs
 puts "=== customize FreeRTOS heap size 0x16000000 (352M)"
 bsp config total_heap_size 0x16000000
+puts "=== Configure Macro configGENERATE_RUN_TIME_STATS to 1 FreeRTOS Config"
 bsp config generate_runtime_stats 1
 
 platform write


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added CPU Consumption % stats support for each task.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is an improvement on top of the existing feature.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Implemented Task Usage logic with Free RTOS API stack.

#### Risks (if any) associated the changes in the commit
A failure case needs to be handled if the Total Time consumed by all tasks is Zero which will and should never happen.

#### What has been tested and how, request additional testing if necessary
Sysfs node for this feature vmr_task_stats is observed and a new column of CPU Usage % is reported for each of our 5 tasks.
Results in attached image.
![MicrosoftTeams-image](https://user-images.githubusercontent.com/111782805/194188754-7c5df893-c9ee-4716-a806-61805e43b832.png)

Additional testing was done to verify the edge case if configGENERATE_RUN_TIME_STATS  is not set in BSP Ctl, stats reports remaining fields and <1% for Usage Percentage.
![image](https://user-images.githubusercontent.com/111782805/194426263-f8d9161e-7ed5-4a30-967f-ea82aa4488f3.png)


#### Documentation impact (if any)
configGENERATE_RUN_TIME_STATS  macro needs to be taken care in BSP ctl file.