### PR TITLE
Fix for CR-1143055

### DIFF
--- a/vmr/src/vmc/platforms/v70.c
+++ b/vmr/src/vmc/platforms/v70.c
@@ -406,7 +406,7 @@ s8 V70_Asdm_Read_Current_3v3(snsrRead_t *snsrData) {
 s8 V70_Asdm_Read_Current_Vccint(snsrRead_t *snsrData)
 {
 	s8 status = XST_SUCCESS;
-	u16 current = (sensor_glvr.sensor_readings.current[eVCCINT] * 1000);
+	u32 current = (sensor_glvr.sensor_readings.current[eVCCINT] * 1000);
 
 	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
 	snsrData->sensorValueSize = sizeof(current);

--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -417,7 +417,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 	{
 	    .repoType = CurrentSDR,
 	    .sensorName = VCCINT_NAME,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
 	    .snsrUnitModifier = -3,
 	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
 	    .sampleCount = 0x1,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
To prevent the counter from rolling over in the event of higher current readings, we are now sending 4 bytes of the VccINT current value.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1143055
#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified the data type.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
ran xbtest and validated the VccINT current values.
#### Documentation impact (if any)
NA