### PR TITLE
Fix for CR-1139982

### DIFF
--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -28,8 +28,8 @@
 #include "platforms/vck5000.h"
 #include "platforms/v70.h"
 
-#define BITMASK_TO_CLEAR	0xFF00000F
-#define ENABLE_FORCE_SHUTDOWN	0x001B6320
+#define BITMASK_TO_CLEAR	0xFFF0000F
+#define ENABLE_FORCE_SHUTDOWN	0x000DB190
 
 static int vmc_sysmon_is_ready = 0;
 /* TODO: init those to a certain value */


### PR DESCRIPTION
	- UCS subsystem clock shutdown magic number updated. (https://confluence.xilinx.com/display/DCG/Versal+User+Clock+Control+IP)

Signed-off-by: Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VCK5000: Clock shutdown working without any issues.
V70: Clock shutdown causing PCI-E link failures. But these changes are needed in VMC as we tested clock shutdown without any issues through the Demo menu.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1139982
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
-> PCI-E link failure appears only while running xbtest(When sensors values are above critical threshold limits, Even tried with lower threshold values )
-> Enabled clock shutdown via debug menu and tried more than 20 times clock shutdown, No issue at all.
#### Documentation impact (if any)
NA