### PR TITLE
Fix for CR-1139363: XRT reports sc version as 0.0.0

### DIFF
--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -131,6 +131,9 @@ void cl_msg_handle_complete(cl_msg_t *msg)
 		/* pass back apu status */
 		cmd_cq->cq_vmr_payload.ps_is_ready = cl_rmgmt_apu_is_ready();
 		cmd_cq->cq_vmr_payload.pl_is_ready = cl_rmgmt_pl_is_ready();
+		
+		/* pass back status, SC is ready and VMC has SC version */
+		cmd_cq->cq_vmr_payload.sc_is_ready = cl_vmc_has_sc_version();
 
 		/* pass back log level and flash progress */
 		cmd_cq->cq_vmr_payload.debug_level = cl_loglevel_get();

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -18,6 +18,7 @@
 #define VMR_IDENTIFY_CMD_MAJOR		1
 #define VMR_IDENTIFY_CMD_MINOR		0
 
+
 /**
  * clock scaling request types
  */
@@ -204,17 +205,17 @@ struct xgq_cmd_vmr_control_payload {
 };
 
 /**
- * struct xgq_cmd_clk_scaling_payload: clock scaling request command
+ * struct xgq_cmd_clk_scaling_payload: clock_scaling configuration request command
  *
- * @aid:			Application Id or command code
- * @scaling_en:			Enable Clock Throttling
- * @pwr_scaling_ovrd_limit:	Set Override for Power Throttling
- * @temp_scaling_ovrd_limit:	Set Override for Temperature Throttling
- * @rsvd:			reserved
+ * @aid: Clock scaling API ID which decides API in VMC.
+ *          0x1 - READ_CLOCK_THROTTLING_CONFIGURATION
+ *          0x2 - SET_CLOCK_THROTTLING_CONFIGURATION
+ * @scaling_enable: enable or disable flag
+ * @pwr_ovrd: power override value
+ * @temp_ovrd: temperature override value
  *
- * This payload is used for Enable and/or Override Clock Throttling Limits.
+ * This payload is used for clock scaling configuration report.
  */
-
 struct xgq_cmd_clk_scaling_payload {
 	uint32_t aid:3;
 	uint32_t scaling_en:1;
@@ -299,7 +300,7 @@ struct xgq_cmd_cq_data_payload {
 	uint32_t resvd1;
 };
 
-/*
+/**
  * struct xgq_cmd_cq_clk_scaling_payload: clock scaling status payload
  *
  * clock scaling status
@@ -333,7 +334,8 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t has_ext_sysdtb:1;
 	uint16_t ps_is_ready:1;
 	uint16_t pl_is_ready:1;
-	uint16_t resvd1:5;
+	uint16_t sc_is_ready:1;
+	uint16_t resvd1:4;
 	uint16_t current_multi_boot_offset;
 	uint32_t debug_level:3;
 	uint32_t program_progress:7;
@@ -347,9 +349,9 @@ struct xgq_cmd_cq_vmr_payload {
  * VMR Identify Command
 */
 struct xgq_cmd_cq_vmr_identify_payload {
-    uint16_t ver_major;
-    uint16_t ver_minor;
-    uint32_t resvd;
+	uint16_t ver_major;
+	uint16_t ver_minor;
+	uint32_t resvd;
 };
 
 /*
@@ -360,10 +362,11 @@ struct xgq_cmd_cq_vmr_identify_payload {
  * @default_payload: 	payload definitions in a union
  * @clock_payload:
  * @sensor_payload:
- * @vmr_payload:
+ * @multiboot_payload:
  * @log_payload:
- * @xclbin_payload
- * @clk_scaling_payload
+ * @xclbin_payload:
+ * @clk_scaling_payload:
+ * @vmr_identify_payload:
  */
 struct xgq_cmd_cq {
 	struct xgq_cmd_cq_hdr hdr;

--- a/vmr/src/include/cl_vmc.h
+++ b/vmr/src/include/cl_vmc.h
@@ -52,4 +52,5 @@ int cl_vmc_clk_scaling(struct cl_msg *msg);
 void cl_vmc_get_clk_throttling_params(clk_throttling_params_t *params);
 int cl_vmc_clk_throttling_disable();
 int cl_vmc_clk_throttling_enable();
+int cl_vmc_has_sc_version(void);
 #endif

--- a/vmr/src/vmc/vmc_sc_comms.c
+++ b/vmr/src/vmc/vmc_sc_comms.c
@@ -267,8 +267,9 @@ bool Parse_SC_Data(u8 *Payload, u8 expected_msgid)
 		VMC_Update_Sensors(Payload[PayloadLength], &Payload[COMMS_PAYLOAD_START_INDEX]);
 		break;
 	case MSP432_COMMS_VMC_VERSION_POWERMODE_RESP:
-		vmc_set_power_mode_status(true);
 		VMC_Update_Version_PowerMode(Payload[PayloadLength], &Payload[COMMS_PAYLOAD_START_INDEX]);
+		vmc_set_power_mode_status(true);
+		VMC_LOG("SC version Received");
 		break;
 	case MSP432_COMMS_VMC_GET_RESP_SIZE_RESP:
 		VMC_Update_Sensor_Length(Payload[PayloadLength], &Payload[COMMS_PAYLOAD_START_INDEX]);
@@ -635,6 +636,11 @@ int cl_vmc_sc_is_ready()
 	cl_vmc_sc_active();
 
 	return (vmc_get_sc_status() == true);
+}
+
+int cl_vmc_has_sc_version()
+{
+	return (vmc_get_power_mode_status() == true);
 }
 
 u8 VMC_Poll_SC_Sensors()


### PR DESCRIPTION
- Add new flag in vmr_status to notify XRT driver that VMC is ready with SC version data, and driver can start reading sensor values.
- Fix diffs in xgq_cmd_vmr.h b/w VMR and XRT repo.

Signed-off-by: Sandeep Kumar Thakur <sandeep.thakur@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1139363

#### How problem was solved, alternative solutions (if any) and why they were rejected
VMR (VMC) to notify XRT that SC is active and has successfully read the version within 200 secs of the bootup, failing which XRT would block any further sensor operation.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
We test with test vmr.elf with similar XRT changes, and validated SC version is displayed correctly on tool after a xbutil reset

```
[0000:3b:00.0] : xilinx_vck5000_gen4x8_qdma_base_2
Vmr Status
Build flags : default full build
Vitis version : 2022.2_daily_latest
Git hash : 5d037a0b014df8e83d756adfebb92af6ebe4323e
Git branch : main
Git hash date : Wed, 19 Oct 2022 08
Vmr build date : Fri Oct 21 11
Vmr build version : 0.0.0.0
Default image offset : 0x48000
Default image size : 0x65d780
Default image capacity : 0x5fb8000
Backup image offset : 0x6008000
Backup image size : 0x65cfc0
Backup image capacity : 0x5fb8000
Scfw image size : 0x456c2
Scfw image version : 4.4.35
Has fpt : 1
Has fpt recovery : 1
Boot on default : 1
Boot on backup : 0
Boot on recovery : 0
Current multi boot offset : 0x9
Boot on offset : 0x9
Has extfpt : 1
Has ext meta xsabin : 1
Has ext sc fw : 1
Has ext system dtb : 1
Debug level : 0
Program progress : 0
Pl is ready : 1
Ps is ready : 0
Sc is ready : 1
```

#### Documentation impact (if any)
Please refer CR for detailed comments