### PR TITLE
Fix for CR-1139982

### DIFF
--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -659,7 +659,7 @@ static u32 check_clock_shutdown_status(void)
 	u32 shutdown_status = 0 ;
 
 	//offset to read shutdown status
-	shutdown_status = IO_SYNC_READ32(VMR_EP_UCS_CONTROL_STATUS_BASEADDR);
+	shutdown_status = IO_SYNC_READ32(VMR_EP_GAPPING_DEMAND + VMR_EP_UCS_CHANNEL_2);
 
 	return (shutdown_status & SHUTDOWN_LATCHED_STATUS);
 }


### PR DESCRIPTION
	-> Clock shutdown procedure is changed to avoid PCI-E link error when we do complete clock shutdown.
	-> New implementation will reduce the clock speed to 5%. Below are steps

	Step1: Write bit[20] to 0x1 in the Gapping Demand Control register at offset 0x0000
		This will enable the feature to throttle the clock on a clock shutdown event to a max of 25%, rather than stopping the clock
		(25% is a bit higher, so decide to run at 5%)
	Step2: Write magic number(0xDB190) to 0x80031008 .
	Step3: After writing the magic number, the shutdown request latched status (Gapping Demand Status register bit[0], offset 0x0008) will be set.
	Step4: when the shutdown request latched status is set, clock shutdown message will be pushed to dmessage.
    	Step5: Hot reset by XRT.

Signed-off-by: Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, and remove sections that don't apply to your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1139982
#### Bug/issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How the problem was solved, alternative solutions (if any), and why they were rejected
NA
#### Risks (if any) associated with the changes in the commit
NA
#### What has been tested and how request additional testing if necessary
Tested with xbtest in both V70 and VCK5000.
Able to see the power drop when clock speed is reduced to 5%.
Able to see clock shutdown message on dmesg logs(host side).
Hot reset by XRT happening in both v70 and vck5000.
#### Documentation impact (if any)
