### PR TITLE
CR-1143963 ASTeR TS 7 - v70 - xbtest stress hangs when ran with the APU

### DIFF
--- a/build/dts/v70_2022.2.dtsi
+++ b/build/dts/v70_2022.2.dtsi
@@ -162,6 +162,11 @@
             no-map;
             reg = <0x501 0x80000000 0x0 0x7fffffff>;
         };
+        
+        zocl_versal_region2: buffer@60000000000 {
+            no-map;
+            reg = <0x600 0x0 0x02 0x0>;
+        };
 
     };
 


### PR DESCRIPTION
loaded

Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1143963
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested fixed.

#### Documentation impact (if any)
