### PR TITLE
CR-1144466 In rmgmt_apu_identify: Use of an uninitialized variable (CWE-457)

### DIFF
--- a/vmr/src/common/cl_xgq_client.c
+++ b/vmr/src/common/cl_xgq_client.c
@@ -220,8 +220,8 @@ int rmgmt_apu_identify(struct xgq_vmr_cmd_identify *id_cmd)
 {
 	int rval = 0;
 	uint64_t slot_addr = 0;
-	struct xgq_cmd_sq sq_cmd;
-	struct xgq_cmd_cq cq_cmd;
+	struct xgq_cmd_sq sq_cmd = { 0 };
+	struct xgq_cmd_cq cq_cmd = { 0 };
 
 	if (!cl_rmgmt_apu_is_ready())
 		return -ENODEV;


### PR DESCRIPTION
Signed-off-by: prapulkrishnamurthy <prapulk@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Minor fix with variables initialized

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Variables Initialized

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
NA

#### Documentation impact (if any)
NA