### PR TITLE
CR-1144465 In GicSetupInterruptSystem: Use of an uninitialized variable (CWE-457)

### DIFF
--- a/vmr/src/rmgmt/gic_setup.c
+++ b/vmr/src/rmgmt/gic_setup.c
@@ -17,7 +17,7 @@ static GicIrqEntry GicIrqTable[XSCUGIC_MAX_NUM_INTR_INPUTS];
 
 s32 GicSetupInterruptSystem(XScuGic *GicInst)
 {
-	s32 Status;
+	s32 Status = XST_SUCCESS;
 
 	XScuGic_Config *GicCfgPtr = XScuGic_LookupConfig(INTC_DEVICE_ID);
 	if (NULL == GicCfgPtr) {


### PR DESCRIPTION
Signed-off-by: prapulkrishnamurthy <prapulk@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Local Variable Initialization

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Variable Initialized

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
NA

#### Documentation impact (if any)
NA