### PR TITLE
new vmr test will take TA as an env and exclude base_1

### DIFF
--- a/docker/vmr_setup_build.sh
+++ b/docker/vmr_setup_build.sh
@@ -13,6 +13,7 @@ sudo dpkg -i /proj/xbuilds/${TA}/xbb/xrt/packages/apu_packages/xrt-apu-vck5000*a
 
 #Run VMR build
 ./build.sh
+md5sum *.elf
 
 #Source settings.sh
 source /proj/xbuilds/${TA}/installs/lin64/Vitis/HEAD/settings64.sh


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VMR pipeline will take stable TA from env 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
should not install qdma-1 shell 
#### How problem was solved, alternative solutions (if any) and why they were rejected
modify base pkg file pattern to be base_2 only
#### Risks (if any) associated the changes in the commit
none
#### What has been tested and how, request additional testing if necessary
na
#### Documentation impact (if any)
na