### PR TITLE
CR-1144465 In GicSetupInterruptSystem: Use of an uninitialized variable (CWE-457)

### DIFF
--- a/vmr/src/rmgmt/gic_setup.c
+++ b/vmr/src/rmgmt/gic_setup.c
@@ -50,7 +50,7 @@ done:
 
 s32 GicResume(XScuGic *GicInst)
 {
-	s32 Status = XST_SUCCESS;
+	s32 Status = XST_FAILURE;
 	u32 i;
 
 	GicInst->IsReady = 0U;


### PR DESCRIPTION
Signed-off-by: prapulkrishnamurthy <prapulk@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Initialized a Variable
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
VMR is building and did a sanity check; VMR correctly working
#### Documentation impact (if any)
This is a simple fix