### PR TITLE
refactor rmgmt_xfer to receive pdi from shared memory directly

### DIFF
--- a/vmr/src/common/cl_xgq_client.c
+++ b/vmr/src/common/cl_xgq_client.c
@@ -161,7 +161,7 @@ int rmgmt_apu_download_xclbin(struct rmgmt_handler *rh)
 	if (!cl_rmgmt_apu_is_ready())
 		return -ENODEV;
 
-	data = (char *)rh->rh_data;
+	data = (char *)rh->rh_data_base;
 	size = rh->rh_data_size;
 	priv = rh->rh_data_priv;
 	remain_size = size;

--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -103,6 +103,7 @@ static int xclbin_handle(cl_msg_t *msg, struct xgq_cmd_sq *sq)
 {
 	msg->data_payload.address = (u32)sq->xclbin_payload.address;
 	msg->data_payload.size = (u32)sq->xclbin_payload.size;
+	msg->data_payload.remain_size = (u32)sq->xclbin_payload.remain_size;
 	msg->data_payload.priv = sq->xclbin_payload.priv;
 
 	return 0;

--- a/vmr/src/include/cl_msg.h
+++ b/vmr/src/include/cl_msg.h
@@ -78,6 +78,7 @@ typedef enum cl_clk_scaling_type {
 struct xgq_vmr_data_payload {
 	uint32_t address;
 	uint32_t size;
+	uint32_t remain_size;
 	uint32_t addr_type:4;
 	uint32_t flash_no_backup:1;
 	uint32_t flash_to_legacy:1;

--- a/vmr/src/include/cl_rmgmt.h
+++ b/vmr/src/include/cl_rmgmt.h
@@ -9,14 +9,14 @@
 struct cl_msg;
 
 struct rmgmt_handler {
-	u32 rh_base;   /* obsolated */
 	u32 rh_boot_on_offset;
 	u32 rh_data_max_size;
 	u32 rh_data_size;
+	u32 rh_data_base;   	/* data base address, or 0(NULL) */
 	void *rh_data_priv;
 	u32 rh_log_max_size; 
-	char *rh_log;	/* static malloc and never free */
-	u8   *rh_data; 	/* static malloc and never free */
+	char *rh_log;		/* static malloc and never free */
+	u8   *rh_data_buffer; 	/* static malloc and never free */
 	int  rh_already_flashed; /* enforce reset/reboot after successfully flashed */
 };
 

--- a/vmr/src/rmgmt/rmgmt_fpt.c
+++ b/vmr/src/rmgmt/rmgmt_fpt.c
@@ -408,7 +408,7 @@ int rmgmt_flash_rpu_pdi(struct rmgmt_handler *rh, struct cl_msg *msg)
 	u32 offset = 0;
 	u32 len = 0;
 	u32 plm_boot_tag = 0;
-	struct axlf *axlf = (struct axlf *)rh->rh_data;
+	struct axlf *axlf = (struct axlf *)rh->rh_data_base;
 	uint64_t pdi_offset = 0;
 	uint64_t pdi_size = 0;
 	u8 *pdi_data = NULL;

--- a/vmr/src/rmgmt/rmgmt_xfer.c
+++ b/vmr/src/rmgmt/rmgmt_xfer.c
@@ -21,176 +21,21 @@
 #define CLK_TYPE_SYSTEM 2
 #define CLK_TYPE_MAX    4
 
-static inline u32 wait_for_status(struct rmgmt_handler *rh, u8 status)
-{
-	u32 header;
-	struct pdi_packet *pkt = (struct pdi_packet *)&header;
-
-        for (;;) {
-                header = IO_SYNC_READ32(rh->rh_base);
-                if (pkt->pkt_status == status)
-                        break;
-        }
-
-        return header;
-}
-
-u8 rmgmt_get_pkt_flags(struct rmgmt_handler *rh)
-{
-        struct pdi_packet *pkt;
-        u32 header;
-
-        pkt = (struct pdi_packet *)&header;
-        header = IO_SYNC_READ32(rh->rh_base);
-        return pkt->pkt_flags;
-}
-
-int rmgmt_check_for_status(struct rmgmt_handler *rh, u8 status)
-{
-        struct pdi_packet *pkt;
-        u32 header;
-
-        pkt = (struct pdi_packet *)&header;
-        header = IO_SYNC_READ32(rh->rh_base);
-
-        return (pkt->pkt_status == status);
-}
-
-static inline void set_flags(struct rmgmt_handler *rh, u8 flags)
-{
-        struct pdi_packet *pkt;
-        u32 header;
-
-        pkt = (struct pdi_packet *)&header;
-        header = IO_SYNC_READ32(rh->rh_base);
-        pkt->pkt_flags = flags;
-
-        IO_SYNC_WRITE32(pkt->header, rh->rh_base);
-}
-
-static inline void set_version(struct rmgmt_handler *rh)
-{
-        set_flags(rh, XRT_XFR_VER <<  XRT_XFR_PKT_VER_SHIFT);
-}
-
-static inline void set_status(struct rmgmt_handler *rh, u8 status)
-{
-	volatile struct pdi_packet *pkt;
-	volatile u32 header;
-
-        header = IO_SYNC_READ32(rh->rh_base);
-        pkt = (struct pdi_packet *)&header;
-        pkt->pkt_status = status;
-
-        IO_SYNC_WRITE32(pkt->header, rh->rh_base);
-}
-
-static inline void read_data32(u32 *addr, u32 *data, size_t sz)
-{
-	u32 i;
-
-	for (i = 0; i < sz; ++i) {
-		*(data + i) = IO_SYNC_READ32((UINTPTR)(addr + i));
-	}
-}
-
-static int rmgmt_data_receive(struct rmgmt_handler *rh, u32 *len)
-{
-	u32 offset = 0;
-	int ret;
-
-	for (;;) {
-		u32 pkt_header;
-		struct pdi_packet *pkt = (struct pdi_packet *)&pkt_header;
-		int lastpkt;
-
-		/* Busy wait here until we get a new packet */
-		pkt_header = wait_for_status(rh, XRT_XFR_PKT_STATUS_NEW);
-		lastpkt = pkt->pkt_flags & XRT_XFR_PKT_FLAGS_LAST;
-
-		if ((offset + pkt->pkt_size) > rh->rh_data_size) {
-			VMR_DBG("max: %d M, received %d M\r\n",
-				rh->rh_data_size / 0x100000,
-				(offset + pkt->pkt_size) / 0x100000);
-			return -1;
-		}
-		/* Read packet data payload on a 4 bytes base */
-		read_data32((u32 *)rh->rh_base + (sizeof(struct pdi_packet)) / 4,
-			(u32 *)(rh->rh_data) + offset / 4,
-			pkt->pkt_size / 4);
-
-		/* Notify host that the data has been read */
-		set_status(rh, XRT_XFR_PKT_STATUS_IDLE);
-
-		/* Set len to next offset */
-		offset += pkt->pkt_size;
-
-		/* Bail out here if this is the last packet */
-		if (lastpkt) {
-			VMR_DBG("\r\n");
-			ret = 0;
-			break;
-		}
-	}
-
-	*len = offset;
-	return ret;
-}
-
-#if 0
-static int rmgmt_init_xfer(struct rmgmt_handler *rh)
-{
-	if (XRT_XFR_RES_SIZE & 0x3) {
-		VMR_LOG("xfer size: %d is not 32bit aligned\r\n", XRT_XFR_RES_SIZE);
-		return -1;
-	}
-
-	/* Special init BRAM from random data to all ZERO */
-	for (int i = 0; i < XRT_XFR_RES_SIZE; i += 4) {
-		IO_SYNC_WRITE32(0x0, rh->rh_base + i * 4);
-	}
-
-	return 0;
-}
-
-static int rmgmt_init_xfer_handler(struct rmgmt_handler *rh)
-{
-	rh->rh_base = OSPI_VERSAL_BASE;
-
-	if (rmgmt_init_xfer(rh) != 0)
-		return -1;
-
-	rh->rh_max_size = BITSTREAM_SIZE; /* 32M */
-	rh->rh_data = (u8 *)malloc(rh->rh_max_size);
-	if (rh->rh_data == NULL) {
-		VMR_LOG("malloc %d bytes failed\r\n", rh->rh_data_size);
-		return -1;
-	}
-
-	/* ospi flash should alreay be initialized */
-
-	set_version(rh);
-	set_status(rh, XRT_XFR_PKT_STATUS_IDLE);
-
-	VMR_DBG("rmgmt_init_handler done\r\n");
-	return 0;
-}
-#endif
-
 int rmgmt_init_handler(struct rmgmt_handler *rh)
 {
+	rh->rh_data_base = 0;
 	rh->rh_data_max_size = BITSTREAM_SIZE; /* 32M */
 	rh->rh_log_max_size = LOG_MSG_SIZE; /* 4K */
 
-	rh->rh_data = (u8 *)pvPortMalloc(rh->rh_data_max_size);
-	if (rh->rh_data == NULL) {
+	rh->rh_data_buffer = (u8 *)pvPortMalloc(rh->rh_data_max_size);
+	if (rh->rh_data_buffer == NULL) {
 		VMR_ERR("pvPortMalloc %d bytes for rh_data failed", rh->rh_data_max_size);
 		return -ENOMEM;
 	}
 
 	rh->rh_log = (char *)pvPortMalloc(rh->rh_log_max_size);
 	if (rh->rh_log == NULL) {
-		vPortFree(rh->rh_data);
+		vPortFree(rh->rh_data_buffer);
 		VMR_ERR("pvPortMalloc %d bytes for rh_log failed", rh->rh_log_max_size);
 		return -ENOMEM;
 	}
@@ -399,7 +244,7 @@ static inline int pdi_download(UINTPTR data, UINTPTR size, const char *clock,
 static int rmgmt_fpga_download(struct rmgmt_handler *rh, u32 len)
 {
 	int ret = 0;
-	struct axlf *axlf = (struct axlf *)rh->rh_data;
+	struct axlf *axlf = (struct axlf *)rh->rh_data_base;
 	uint64_t offset = 0;
 	uint64_t size = 0;
 	char *partial_pdi = NULL;
@@ -483,14 +328,14 @@ int rmgmt_load_apu(struct rmgmt_handler *rh)
 	}
 	VMR_DBG("APU PDI size: %d\r\n", size);
 
-	ret = ospi_flash_read(CL_FLASH_APU, rh->rh_data, OSPI_VERSAL_PAGESIZE, size);
+	ret = ospi_flash_read(CL_FLASH_APU, (u8 *)rh->rh_data_base, OSPI_VERSAL_PAGESIZE, size);
 	if (ret)
 		return ret;
 
 	/* Sync data from cache to memory */
 	Xil_DCacheFlush();
 
-	ret = pdi_download((UINTPTR)rh->rh_data, (UINTPTR)size, NULL, 0, 0);
+	ret = pdi_download((UINTPTR)rh->rh_data_base, (UINTPTR)size, NULL, 0, 0);
 
 	return ret;
 }
@@ -512,7 +357,7 @@ static int rmgmt_ospi_rpu_download(struct rmgmt_handler *rh, u32 len)
 	}
 
 	/* write */
-	ret = ospi_flash_write(CL_FLASH_BOOT, rh->rh_data, base, len);
+	ret = ospi_flash_write(CL_FLASH_BOOT, (u8 *)rh->rh_data_base, base, len);
 	if (ret) {
 		VMR_LOG("OSPI fails to load pdi %d", ret);
 		goto out;
@@ -526,7 +371,7 @@ out:
 static int rmgmt_ospi_apu_download(struct rmgmt_handler *rh, u32 len)
 {
 	int ret = 0;
-	struct axlf *axlf = (struct axlf *)rh->rh_data;
+	struct axlf *axlf = (struct axlf *)rh->rh_data_base;
 	uint64_t offset = 0;
 	uint64_t size = 0;
 	cl_msg_t msg = { 0 };
@@ -565,141 +410,6 @@ static int rmgmt_ospi_apu_download(struct rmgmt_handler *rh, u32 len)
 
 	VMR_LOG("FPGA load pdi ret: %d", ret);
 	return ret;
-}
-
-/* Temporary disable old apu design flow */
-#if 0
-static int rmgmt_ospi_apu_download(struct rmgmt_handler *rh, u32 len)
-{
-	int ret;
-	u8 pdiHeader[OSPI_VERSAL_PAGESIZE] = { 0 };
-
-	VMR_LOG("-> rmgmt_ospi_apu_download\r\n");
-
-	*((u32 *)pdiHeader) = MAGIC_NUM32;
-	*((u32 *)pdiHeader + 1) = len;
-
-	/* Sync data from cache to memory */
-	Xil_DCacheFlush();
-
-	ret = ospi_flash_erase(CL_FLASH_APU, 0, OSPI_VERSAL_PAGESIZE + len);
-	if (ret) {
-		set_status(rh, XRT_XFR_PKT_STATUS_FAIL);
-		VMR_DBG("OSPI fails to load pdi %d\r\n", ret);
-		goto out;
-	}
-
-	/* flash rpu base pdi from offset 0(RPU_PDI_ADDRES) */
-	ret = ospi_flash_write(CL_FLASH_APU, pdiHeader,
-		0, OSPI_VERSAL_PAGESIZE);
-	if (ret) {
-		set_status(rh, XRT_XFR_PKT_STATUS_FAIL);
-		VMR_DBG("OSPI fails to load pdi %d\r\n", ret);
-		goto out;
-	}
-
-	ret = ospi_flash_write(CL_FLASH_APU, rh->rh_data,
-		OSPI_VERSAL_PAGESIZE, len);
-	if (ret) {
-		set_status(rh, XRT_XFR_PKT_STATUS_FAIL);
-		VMR_DBG("OSPI fails to load pdi %d\r\n", ret);
-		goto out;
-	}
-
-	set_status(rh, XRT_XFR_PKT_STATUS_DONE);
-out:
-	VMR_LOG("<- rmgmt_ospi_apu_download %d\r\n", ret);
-	return ret;
-}
-#endif
-
-static int rmgmt_recv_pkt(struct rmgmt_handler *rh, u32 *len)
-{
-	int ret;
-
-	VMR_DBG("-> rmgmt_recv_pkt\r\n");
-
-	ret = rmgmt_data_receive(rh, len);
-	if (ret) {
-		set_status(rh, XRT_XFR_PKT_STATUS_FAIL);
-		VMR_DBG("Fail to receive pkt %d\r\n", ret);
-		goto out;
-	}
-
-	/*TODO: verify signature */
-
-	VMR_DBG("<- rmgmt_recv_pkt\r\n");
-out:
-	return ret;
-}
-
-static void rmgmt_done_pkt(struct rmgmt_handler *rh)
-{
-	wait_for_status(rh, XRT_XFR_PKT_STATUS_IDLE);
-
-	set_version(rh);
-
-	VMR_DBG("<-");
-}
-
-struct rmgmt_ops {
-	int (*rmgmt_recv_op)(struct rmgmt_handler *rh, u32 *len);
-	int (*rmgmt_download_op)(struct rmgmt_handler *rh, u32 len);
-	void (*rmgmt_done_op)(struct rmgmt_handler *rh);
-};
-
-static struct rmgmt_ops xfer_rpu_ops = {
-	.rmgmt_recv_op = rmgmt_recv_pkt,
-	.rmgmt_download_op = rmgmt_ospi_rpu_download,
-	.rmgmt_done_op = rmgmt_done_pkt,
-};
-
-static struct rmgmt_ops xfer_apu_ops = {
-	.rmgmt_recv_op = rmgmt_recv_pkt,
-	.rmgmt_download_op = rmgmt_ospi_apu_download,
-	.rmgmt_done_op = rmgmt_done_pkt,
-};
-
-static struct rmgmt_ops xfer_xclbin_ops = {
-	.rmgmt_recv_op = rmgmt_recv_pkt,
-	.rmgmt_download_op = rmgmt_fpga_download,
-	.rmgmt_done_op = rmgmt_done_pkt,
-};
-
-static int rmgmt_xfer_download(struct rmgmt_handler *rh, struct rmgmt_ops *ops)
-{
-	u32 len;
-	int ret;
-
-	if (ops == NULL) {
-		VMR_DBG("rmgmt_ops cannot be NULL\r\n");
-		return -1;
-	}
-
-	ret = ops->rmgmt_recv_op(rh, &len);
-	if (ret)
-		goto done;
-
-	ret = ops->rmgmt_download_op(rh, len);
-
-done:
-	ops->rmgmt_done_op(rh);
-	return ret;
-}
-
-int rmgmt_xfer_download_xclbin(struct rmgmt_handler *rh)
-{
-	return rmgmt_xfer_download(rh, &xfer_xclbin_ops);
-}
-
-int rmgmt_xfer_download_rpu_pdi(struct rmgmt_handler *rh)
-{
-	return rmgmt_xfer_download(rh, &xfer_rpu_ops);
-}
-
-int rmgmt_xfer_download_apu_pdi(struct rmgmt_handler *rh)
-{
-	return rmgmt_xfer_download(rh, &xfer_apu_ops);
 }
 
 int rmgmt_download_xclbin(struct rmgmt_handler *rh)

--- a/vmr/src/rmgmt/rmgmt_xfer.h
+++ b/vmr/src/rmgmt/rmgmt_xfer.h
@@ -7,14 +7,6 @@
 #define RMGMT_XFER_H
 
 /* Versal Platform related definition */
-/*
- #define OSPI_VERSAL_BASE (XPAR_PSV_OCM_RAM_0_S_AXI_BASEADDR + 0x8000)
- This is obsolated for discovery shell, only valide for legacy shell which
- has bram shared bewteen host and device.
- TODO: Remove this when rmgmt_xfer versal ospi sudo code is removed.
-*/
-#define OSPI_VERSAL_BASE (0xFFFE0000 + 0x8000)
-
 #define TEST_ADDRESS	0x0
 
 #define BITSTREAM_SIZE	0x8000000U /* Bin or bit or PDI image max size (128M) */


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
this is for reducing dup code in rmgmt for downloading data. We don't have to do memory copy for now and also remove some obsoleted code.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
tested with latest vck5000 shell

#### Documentation impact (if any)
