### PR TITLE
Modified Asdm_Get_SDR_Size API

### DIFF
--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -993,8 +993,8 @@ s8 Asdm_Get_SDR_Size(u8 *req, u8 *resp, u16 *respSize)
     *respSize += sizeof(u8);
 
     /* Fill the Size of the SDR */
-    sdrSize = sizeof(Asdm_Header_t) + (sdrInfo[sdrIndex].header.no_of_bytes * 8)
-    		 + sizeof(Asdm_EOR_t);
+    sdrSize = sizeof(Asdm_Header_t) + (sdrInfo[sdrIndex].header.no_of_bytes * 8);
+
     Cl_SecureMemcpy(&resp[2],sizeof(sdrSize),&sdrSize, sizeof(sdrSize));
 
     *respSize +=  sizeof(sdrSize);


### PR DESCRIPTION
- Removed addition of sizeofEOR in Asdm_Get_SDR_Size API

Signed-off-by: K Thirukumaran <thirukumaran.k@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Asdm_Get_SDR_Size API sends additional 4 bytes size for all SDRs. Current change sends correct size of SDR.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Through test function(UT) it was discovered.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The size of EOR is already added in Init_Asdm(). It was again added in **Asdm_Get_SDR_Size()** API. 
In Asdm_Get_SDR_Size API, removed adding **sizeofEOR** .

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested Asdm_Get_SDR_Size API using test funtions(UT). 

#### Documentation impact (if any)
NA