### PR TITLE
Address CR-1145637

### DIFF
--- a/vmr/src/vmc/platforms/v70.c
+++ b/vmr/src/vmc/platforms/v70.c
@@ -32,18 +32,18 @@ extern clk_throttling_params_t g_clk_throttling_params;
 static u8 i2c_main = LPD_I2C_0;
 
 u8 V70_VMC_SC_Comms_Msg[] = {
-		SC_COMMS_TX_I2C_SNSR
+        SC_COMMS_TX_I2C_SNSR
 };
 
 #define V70_MAX_MSGID_COUNT     (sizeof(V70_VMC_SC_Comms_Msg)/sizeof(V70_VMC_SC_Comms_Msg[0]))
-#define MAX(a,b)	((a>b) ? a : b)
+#define MAX(a,b)    ((a>b) ? a : b)
 
-#define V70_NUM_BOARD_INFO_SENSORS	(11)
-#define V70_NUM_TEMPERATURE_SENSORS	(3)
-#define V70_NUM_SC_VOLTAGE_SENSORS	(2)
-#define V70_NUM_SYSMON_VOLTAGE_SENSORS	(1)
-#define V70_NUM_SC_CURRENT_SENSORS	(3)
-#define V70_NUM_POWER_SENSORS		(1)
+#define V70_NUM_BOARD_INFO_SENSORS  (11)
+#define V70_NUM_TEMPERATURE_SENSORS (3)
+#define V70_NUM_SC_VOLTAGE_SENSORS  (2)
+#define V70_NUM_SYSMON_VOLTAGE_SENSORS  (1)
+#define V70_NUM_SC_CURRENT_SENSORS  (3)
+#define V70_NUM_POWER_SENSORS       (1)
 
 extern platform_sensors_monitor_ptr Monitor_Sensors;
 extern supported_sdr_info_ptr get_supported_sdr_info;
@@ -59,141 +59,141 @@ void V70_Current_Monitor_3v3_PEX(void);
 void V70_Voltage_Monitor_3v3_AUX(void);
 
 AsdmHeader_info_t v70_asdmHeader_info[] = {
-		{BoardInfoSDR,		V70_NUM_BOARD_INFO_SENSORS},
-		{TemperatureSDR,	V70_NUM_TEMPERATURE_SENSORS},
-		{VoltageSDR,		V70_NUM_SC_VOLTAGE_SENSORS + V70_NUM_SYSMON_VOLTAGE_SENSORS},
-		{CurrentSDR,		V70_NUM_SC_CURRENT_SENSORS},
-		{PowerSDR,		V70_NUM_POWER_SENSORS},
+        {BoardInfoSDR,      V70_NUM_BOARD_INFO_SENSORS},
+        {TemperatureSDR,    V70_NUM_TEMPERATURE_SENSORS},
+        {VoltageSDR,        V70_NUM_SC_VOLTAGE_SENSORS + V70_NUM_SYSMON_VOLTAGE_SENSORS},
+        {CurrentSDR,        V70_NUM_SC_CURRENT_SENSORS},
+        {PowerSDR,      V70_NUM_POWER_SENSORS},
 };
-#define MAX_SDR_REPO 	(sizeof(v70_asdmHeader_info)/sizeof(v70_asdmHeader_info[0]))
+#define MAX_SDR_REPO    (sizeof(v70_asdmHeader_info)/sizeof(v70_asdmHeader_info[0]))
 
 u32 V70_Supported_Sensors[] = {
-	eProduct_Name,
-	eSerial_Number,
-	ePart_Number,
-	eRevision,
-	eMfg_Date,
-	eUUID,
-	eMAC_0,
-	eFpga_Fan_1,
-	eActive_SC_Ver,
-	eTarget_SC_Ver,
-	eOEM_Id,
+    eProduct_Name,
+    eSerial_Number,
+    ePart_Number,
+    eRevision,
+    eMfg_Date,
+    eUUID,
+    eMAC_0,
+    eFpga_Fan_1,
+    eActive_SC_Ver,
+    eTarget_SC_Ver,
+    eOEM_Id,
 
-	/* Temperature SDR */
-	eTemp_Board,
-	eTemp_Sysmon_Fpga,
-	eTemp_Vccint,
+    /* Temperature SDR */
+    eTemp_Board,
+    eTemp_Sysmon_Fpga,
+    eTemp_Vccint,
 
-	/* Voltage SDR */
-	eVoltage_Group_Sensors,
-	eVoltage_Sysmon_Vccint,
+    /* Voltage SDR */
+    eVoltage_Group_Sensors,
+    eVoltage_Sysmon_Vccint,
 
-	/* Current SDR */
-	eCurrent_Group_Sensors,
+    /* Current SDR */
+    eCurrent_Group_Sensors,
 
-	/* Power SDR */
-	ePower_Total
+    /* Power SDR */
+    ePower_Total
 };
 
 void V70_Get_Supported_Sdr_Info(u32 *platform_Supported_Sensors, u32 *sdr_count)
 {
-	*sdr_count = (sizeof(V70_Supported_Sensors) / sizeof(V70_Supported_Sensors[0]));
-	Cl_SecureMemcpy(platform_Supported_Sensors, sizeof(V70_Supported_Sensors),
-			V70_Supported_Sensors,sizeof(V70_Supported_Sensors));
+    *sdr_count = (sizeof(V70_Supported_Sensors) / sizeof(V70_Supported_Sensors[0]));
+    Cl_SecureMemcpy(platform_Supported_Sensors, sizeof(V70_Supported_Sensors),
+            V70_Supported_Sensors,sizeof(V70_Supported_Sensors));
 
-	return;
+    return;
 }
 
 void V70_Asdm_Update_Record_Count(Asdm_Header_t *headerInfo)
 {
-	u8 i = 0;
-	for(i=0; i < MAX_SDR_REPO; i++)
-	{
-		if(headerInfo[i].repository_type == v70_asdmHeader_info[i].record_type) {
-			headerInfo[i].no_of_records = v70_asdmHeader_info[i].record_count;
-		}
-	}
-	return;
+    u8 i = 0;
+    for(i=0; i < MAX_SDR_REPO; i++)
+    {
+        if(headerInfo[i].repository_type == v70_asdmHeader_info[i].record_type) {
+            headerInfo[i].no_of_records = v70_asdmHeader_info[i].record_count;
+        }
+    }
+    return;
 }
 
 s8 V70_Temperature_Read_Inlet(snsrRead_t *snsrData)
 {
-	s8 status = XST_FAILURE;
-	s16 tempValue = 0;
+    s8 status = XST_FAILURE;
+    s16 tempValue = 0;
 
-	status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_0_V70, &tempValue);
-	if (status == XST_SUCCESS)
-	{
-		Cl_SecureMemcpy(snsrData->snsrValue,sizeof(tempValue),&tempValue,sizeof(tempValue));
-		snsrData->sensorValueSize = sizeof(tempValue);
-		snsrData->snsrSatus = Vmc_Snsr_State_Normal;
-	}
-	else
-	{
-		snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
-		VMC_DBG("Failed to read slave : 0x%0.2x \n\r", SLAVE_ADDRESS_LM75_0_V70);
-	}
+    status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_0_V70, &tempValue);
+    if (status == XST_SUCCESS)
+    {
+        Cl_SecureMemcpy(snsrData->snsrValue,sizeof(tempValue),&tempValue,sizeof(tempValue));
+        snsrData->sensorValueSize = sizeof(tempValue);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    }
+    else
+    {
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+        VMC_DBG("Failed to read slave : 0x%0.2x \n\r", SLAVE_ADDRESS_LM75_0_V70);
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Temperature_Read_Outlet(snsrRead_t *snsrData)
 {
-	s8 status = XST_FAILURE;
-	s16 tempValue = 0;
+    s8 status = XST_FAILURE;
+    s16 tempValue = 0;
 
-	status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_1_V70, &tempValue);
-	if (status == XST_SUCCESS)
-	{
-		Cl_SecureMemcpy(snsrData->snsrValue,sizeof(tempValue),&tempValue,sizeof(tempValue));
-		snsrData->sensorValueSize = sizeof(tempValue);
-		snsrData->snsrSatus = Vmc_Snsr_State_Normal;
-	}
-	else
-	{
-		snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
-		VMC_DBG("Failed to read slave : 0x%.2x \n\r", SLAVE_ADDRESS_LM75_1_V70);
-	}
+    status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_1_V70, &tempValue);
+    if (status == XST_SUCCESS)
+    {
+        Cl_SecureMemcpy(snsrData->snsrValue,sizeof(tempValue),&tempValue,sizeof(tempValue));
+        snsrData->sensorValueSize = sizeof(tempValue);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    }
+    else
+    {
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+        VMC_DBG("Failed to read slave : 0x%.2x \n\r", SLAVE_ADDRESS_LM75_1_V70);
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Temperature_Read_Board(snsrRead_t *snsrData)
 {
-	s8 status = XST_SUCCESS;
-	s16 TempReading = 0;
+    s8 status = XST_SUCCESS;
+    s16 TempReading = 0;
 
-	TempReading = MAX(sensor_glvr.sensor_readings.board_temp[0], sensor_glvr.sensor_readings.board_temp[1]);
+    TempReading = MAX(sensor_glvr.sensor_readings.board_temp[0], sensor_glvr.sensor_readings.board_temp[1]);
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(TempReading),&TempReading,sizeof(TempReading));
-	snsrData->sensorValueSize = sizeof(TempReading);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(TempReading),&TempReading,sizeof(TempReading));
+    snsrData->sensorValueSize = sizeof(TempReading);
+    snsrData->snsrSatus = Vmc_Snsr_State_Normal;
 
-	return status;
+    return status;
 }
 
 void V70_Temperature_Monitor(void)
 {
-	u8 status = XST_FAILURE;
-	status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_0_V70, &sensor_glvr.sensor_readings.board_temp[0]);
-	if (status == XST_FAILURE)
-	{
-		VMC_DBG("Failed to read LM75_0 \n\r");
-	}
+    u8 status = XST_FAILURE;
+    status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_0_V70, &sensor_glvr.sensor_readings.board_temp[0]);
+    if (status == XST_FAILURE)
+    {
+        VMC_DBG("Failed to read LM75_0 \n\r");
+    }
 
-	status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_1_V70, &sensor_glvr.sensor_readings.board_temp[1]);
-	if (status == XST_FAILURE)
-	{
-		VMC_DBG("Failed to read LM75_1 \n\r");
-	}
+    status = LM75_ReadTemperature(i2c_main, SLAVE_ADDRESS_LM75_1_V70, &sensor_glvr.sensor_readings.board_temp[1]);
+    if (status == XST_FAILURE)
+    {
+        VMC_DBG("Failed to read LM75_1 \n\r");
+    }
 
-	status =  ISL68221_ReadVCCINT_Temperature(i2c_main, SLAVE_ADDRESS_ISL68221, &sensor_glvr.sensor_readings.vccint_temp);
-	if (status == XST_FAILURE)
-	{
-		VMC_DBG("Failed to read Vccint_temp from : 0x%x", SLAVE_ADDRESS_ISL68221);
-	}
-	return;
+    status =  ISL68221_ReadVCCINT_Temperature(i2c_main, SLAVE_ADDRESS_ISL68221, &sensor_glvr.sensor_readings.vccint_temp);
+    if (status == XST_FAILURE)
+    {
+        VMC_DBG("Failed to read Vccint_temp from : 0x%x", SLAVE_ADDRESS_ISL68221);
+    }
+    return;
 }
 
 s32 V70_VMC_Fetch_BoardInfo(u8 *board_snsr_data)
@@ -213,256 +213,287 @@ s32 V70_VMC_Fetch_BoardInfo(u8 *board_snsr_data)
 
 void V70_Voltage_Monitor_12V_PEX()
 {
-	u8 status = XST_FAILURE;
-	float volatge = 0.0;
-	status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 0, &volatge);
-	if(XST_SUCCESS != status)
-	{
-		VMC_ERR("Failed to read 12vPex voltage");
-	}
+    u8 status = XST_FAILURE;
+    float volatge = 0.0;
+    status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 0, &volatge);
+    if(XST_SUCCESS != status)
+    {
+        VMC_ERR("Failed to read 12vPex voltage");
+    }
 
-	sensor_glvr.sensor_readings.voltage[e12V_PEX] = volatge;
+    sensor_glvr.sensor_readings.voltage[e12V_PEX] = volatge;
 }
 
 void V70_Current_Monitor_12V_PEX()
 {
-	u8 status = XST_FAILURE;
-	float current = 0.0;
-	status = INA3221_ReadCurrent(i2c_main, SLAVE_ADDRESS_INA3221, 0, &current);
-	if(XST_SUCCESS != status)
-	{
-		VMC_ERR("Failed to read 12vPex current");
-	}
+    u8 status = XST_FAILURE;
+    float current = 0.0;
+    status = INA3221_ReadCurrent(i2c_main, SLAVE_ADDRESS_INA3221, 0, &current);
+    if(XST_SUCCESS != status)
+    {
+        VMC_ERR("Failed to read 12vPex current");
+    }
 
-	sensor_glvr.sensor_readings.current[e12V_PEX] = current;
+    sensor_glvr.sensor_readings.current[e12V_PEX] = current;
 }
 
 void V70_Voltage_Monitor_3v3_PEX()
 {
-	u8 status = XST_FAILURE;
-	float volatge = 0.0;
-	status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 1, &volatge);
-	if(XST_SUCCESS != status)
-	{
-		VMC_ERR("Failed to read 3v3 pex voltage");
-	}
+    u8 status = XST_FAILURE;
+    float volatge = 0.0;
+    status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 1, &volatge);
+    if(XST_SUCCESS != status)
+    {
+        VMC_ERR("Failed to read 3v3 pex voltage");
+    }
 
-	sensor_glvr.sensor_readings.voltage[e3V3_PEX] = volatge;
+    sensor_glvr.sensor_readings.voltage[e3V3_PEX] = volatge;
 }
 
 void V70_Current_Monitor_3v3_PEX()
 {
-	u8 status = XST_FAILURE;
-	float current = 0.0;
-	status = INA3221_ReadCurrent(i2c_main, SLAVE_ADDRESS_INA3221, 1, &current);
-	if(XST_SUCCESS != status)
-	{
-		VMC_ERR("Failed to read 3v3 Pex current");
-	}
+    u8 status = XST_FAILURE;
+    float current = 0.0;
+    status = INA3221_ReadCurrent(i2c_main, SLAVE_ADDRESS_INA3221, 1, &current);
+    if(XST_SUCCESS != status)
+    {
+        VMC_ERR("Failed to read 3v3 Pex current");
+    }
 
-	sensor_glvr.sensor_readings.current[e3V3_PEX] = current;
+    sensor_glvr.sensor_readings.current[e3V3_PEX] = current;
 }
 
 void V70_Voltage_Monitor_3v3_AUX()
 {
-	u8 status = XST_FAILURE;
-	float volatge = 0.0;
-	status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 2, &volatge);
-	if(XST_SUCCESS != status)
-	{
-		VMC_ERR("Failed to read 3v3 Aux voltage");
-	}
+    u8 status = XST_FAILURE;
+    float volatge = 0.0;
+    status = INA3221_ReadVoltage(i2c_main, SLAVE_ADDRESS_INA3221, 2, &volatge);
+    if(XST_SUCCESS != status)
+    {
+        VMC_ERR("Failed to read 3v3 Aux voltage");
+    }
 
-	sensor_glvr.sensor_readings.voltage[e3V3_AUX] = volatge;
+    sensor_glvr.sensor_readings.voltage[e3V3_AUX] = volatge;
 }
 
 void V70_Power_Monitor()
 {
-	float power_12v_pex = 0.0;
-	float power_3v3_pex = 0.0;
+    float power_12v_pex = 0.0;
+    float power_3v3_pex = 0.0;
 
-	static u8 count_12vpex = 1;
-	static u8 count_3v3pex = 1;
+    static u8 count_12vpex = 1;
+    static u8 count_3v3pex = 1;
 
-	power_12v_pex = (sensor_glvr.sensor_readings.current[e12V_PEX]/1000.0) * (sensor_glvr.sensor_readings.voltage[e12V_PEX]/1000.0);
-	power_3v3_pex = (sensor_glvr.sensor_readings.current[e3V3_PEX]/1000.0) * (sensor_glvr.sensor_readings.voltage[e3V3_PEX]/1000.0);
+    power_12v_pex = (sensor_glvr.sensor_readings.current[e12V_PEX]/1000.0) * (sensor_glvr.sensor_readings.voltage[e12V_PEX]/1000.0);
+    power_3v3_pex = (sensor_glvr.sensor_readings.current[e3V3_PEX]/1000.0) * (sensor_glvr.sensor_readings.voltage[e3V3_PEX]/1000.0);
 
-	sensor_glvr.sensor_readings.total_power = (power_12v_pex + power_3v3_pex);
-	
-	// shutdown clock only if power reached critical threshold continuously for 1sec (100ms*10)
-	if ((power_12v_pex) >= POWER_12VPEX_CRITICAL_THRESHOLD)
-	{
-		if (count_12vpex == MAX_COUNT_TO_WAIT_1SEC)
-		{
-			ucs_clock_shutdown();
-			count_12vpex = 0;
-		}
-		count_12vpex = count_12vpex + 1;
-	}
-	else /* Reset count value to zero when power values below critical limit and count is less than 10 */
-	{
-		if ((count_12vpex != 0) && ((power_12v_pex) < POWER_12VPEX_CRITICAL_THRESHOLD))
-		{
-			count_12vpex = 0;
-		}
-	}
-	if ((power_3v3_pex) >= POWER_3V3PEX_CRITICAL_THRESHOLD)
-	{
-		if (count_3v3pex == MAX_COUNT_TO_WAIT_1SEC)
-		{
-			ucs_clock_shutdown();
-			count_3v3pex = 0;
-		}
-		count_3v3pex = count_3v3pex + 1;
-	}
-	else /* Reset count value to zero when power values below critical limit and count is less than 10 */
-	{
-		if ((count_3v3pex != 0) && ((power_3v3_pex) < POWER_3V3PEX_CRITICAL_THRESHOLD))
-		{
-			count_3v3pex = 0;
-		}
+    /*
+     * If any of 12v or 3v3 pex is zero that means Vmc_Snsr_State_Comms_failure occurred,
+     * so set total_power to zero.
+     * */
+    if(power_12v_pex == 0 || power_3v3_pex == 0)
+        sensor_glvr.sensor_readings.total_power = 0;
+    else
+        sensor_glvr.sensor_readings.total_power = (power_12v_pex + power_3v3_pex);
+    
+    // shutdown clock only if power reached critical threshold continuously for 1sec (100ms*10)
+    if ((power_12v_pex) >= POWER_12VPEX_CRITICAL_THRESHOLD)
+    {
+        if (count_12vpex == MAX_COUNT_TO_WAIT_1SEC)
+        {
+            ucs_clock_shutdown();
+            count_12vpex = 0;
+        }
+        count_12vpex = count_12vpex + 1;
+    }
+    else /* Reset count value to zero when power values below critical limit and count is less than 10 */
+    {
+        if ((count_12vpex != 0) && ((power_12v_pex) < POWER_12VPEX_CRITICAL_THRESHOLD))
+        {
+            count_12vpex = 0;
+        }
+    }
+    if ((power_3v3_pex) >= POWER_3V3PEX_CRITICAL_THRESHOLD)
+    {
+        if (count_3v3pex == MAX_COUNT_TO_WAIT_1SEC)
+        {
+            ucs_clock_shutdown();
+            count_3v3pex = 0;
+        }
+        count_3v3pex = count_3v3pex + 1;
+    }
+    else /* Reset count value to zero when power values below critical limit and count is less than 10 */
+    {
+        if ((count_3v3pex != 0) && ((power_3v3_pex) < POWER_3V3PEX_CRITICAL_THRESHOLD))
+        {
+            count_3v3pex = 0;
+        }
 
-	}
+    }
 }
 
 void V70_Current_Monitor_Vccint()
 {
-	u8 status = XST_SUCCESS;
-	float currentInA = 0.0;
+    u8 status = XST_SUCCESS;
+    float currentInA = 0.0;
 
-	status =  ISL68221_ReadVCCINT_Current(i2c_main, SLAVE_ADDRESS_ISL68221, &currentInA);
-	if(XST_SUCCESS != status)
-	{
-		VMC_ERR("Failed to read Vccint Current ");
-	}
+    status =  ISL68221_ReadVCCINT_Current(i2c_main, SLAVE_ADDRESS_ISL68221, &currentInA);
+    if(XST_SUCCESS != status)
+    {
+        VMC_ERR("Failed to read Vccint Current ");
+    }
 
-	sensor_glvr.sensor_readings.current[eVCCINT] = currentInA; //In Amps
+    sensor_glvr.sensor_readings.current[eVCCINT] = currentInA; //In Amps
 }
 
 s8 V70_Asdm_Read_Power(snsrRead_t *snsrData) {
 
-	s8 status = XST_SUCCESS;
-	u16 total_power = sensor_glvr.sensor_readings.total_power;
+    s8 status = XST_SUCCESS;
+    u16 total_power = sensor_glvr.sensor_readings.total_power;
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(total_power),&total_power,sizeof(total_power));
-	snsrData->sensorValueSize = sizeof(total_power);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    if(total_power != 0){
+        Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(total_power),&total_power,sizeof(total_power));
+        snsrData->sensorValueSize = sizeof(total_power);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    } else{
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Asdm_Read_Voltage_12v(snsrRead_t *snsrData) {
 
-	s8 status = XST_SUCCESS;
+    s8 status = XST_SUCCESS;
 
-	u16 voltage = sensor_glvr.sensor_readings.voltage[e12V_PEX];
+    u16 voltage = sensor_glvr.sensor_readings.voltage[e12V_PEX];
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(voltage),&voltage,sizeof(voltage));
-	snsrData->sensorValueSize = sizeof(voltage);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    if(voltage != 0){
+        Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(voltage),&voltage,sizeof(voltage));
+        snsrData->sensorValueSize = sizeof(voltage);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    } else {
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Asdm_Read_Voltage_3v3(snsrRead_t *snsrData) {
 
-	s8 status = XST_SUCCESS;
+    s8 status = XST_SUCCESS;
 
-	u16 voltage = sensor_glvr.sensor_readings.voltage[e3V3_PEX];
+    u16 voltage = sensor_glvr.sensor_readings.voltage[e3V3_PEX];
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(voltage),&voltage,sizeof(voltage));
-	snsrData->sensorValueSize = sizeof(voltage);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    if(voltage != 0){
+        Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(voltage),&voltage,sizeof(voltage));
+        snsrData->sensorValueSize = sizeof(voltage);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    } else {
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Asdm_Read_Current_12v(snsrRead_t *snsrData) {
 
-	s8 status = XST_SUCCESS;
-	u16 current = sensor_glvr.sensor_readings.current[e12V_PEX];
+    s8 status = XST_SUCCESS;
+    u16 current = sensor_glvr.sensor_readings.current[e12V_PEX];
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
-	snsrData->sensorValueSize = sizeof(current);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    if(current != 0){
+        Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
+        snsrData->sensorValueSize = sizeof(current);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    } else {
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Asdm_Read_Current_3v3(snsrRead_t *snsrData) {
 
-	s8 status = XST_SUCCESS;
-	u16 current = sensor_glvr.sensor_readings.current[e3V3_PEX];
+    s8 status = XST_SUCCESS;
+    u16 current = sensor_glvr.sensor_readings.current[e3V3_PEX];
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
-	snsrData->sensorValueSize = sizeof(current);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    if(current != 0){
+        Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
+        snsrData->sensorValueSize = sizeof(current);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    } else {
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Asdm_Read_Current_Vccint(snsrRead_t *snsrData)
 {
-	s8 status = XST_SUCCESS;
-	u32 current = (sensor_glvr.sensor_readings.current[eVCCINT] * 1000);
+    s8 status = XST_SUCCESS;
+    u32 current = (sensor_glvr.sensor_readings.current[eVCCINT] * 1000);
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
-	snsrData->sensorValueSize = sizeof(current);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    if(current != 0){
+        Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(current),&current,sizeof(current));
+        snsrData->sensorValueSize = sizeof(current);
+        snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    } else {
+        snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
+    }
 
-	return status;
+    return status;
 }
 
 s8 V70_Asdm_Read_Temp_Vccint(snsrRead_t *snsrData)
 {
-	s8 status = XST_SUCCESS;
-	u16 temp = (sensor_glvr.sensor_readings.vccint_temp);
+    s8 status = XST_SUCCESS;
+    u16 temp = (sensor_glvr.sensor_readings.vccint_temp);
 
-	Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(temp),&temp,sizeof(temp));
-	snsrData->sensorValueSize = sizeof(temp);
-	snsrData->snsrSatus = Vmc_Snsr_State_Normal;
+    Cl_SecureMemcpy(&snsrData->snsrValue[0],sizeof(temp),&temp,sizeof(temp));
+    snsrData->sensorValueSize = sizeof(temp);
+    snsrData->snsrSatus = Vmc_Snsr_State_Normal;
 
-	/* Shutdown user clock when vccint temperature value goes beyond critical value*/
-	if (temp >= V70_TEMP_VCCINT_CRITICAL_THRESHOLD)
-	{
-	    ucs_clock_shutdown();
-	}
-	return status;
+    /* Shutdown user clock when vccint temperature value goes beyond critical value*/
+    if (temp >= V70_TEMP_VCCINT_CRITICAL_THRESHOLD)
+    {
+        ucs_clock_shutdown();
+    }
+    return status;
 }
 s8 V70_Get_Current_Names(u8 index, char8* snsrName, u8 *sensorId, sensorMonitorFunc *sensor_handler)
 {
-	struct sensorData
-	{
-		char8 sensorName[SENSOR_NAME_MAX];
-		sensorMonitorFunc	sensor_handler;
-	};
+    struct sensorData
+    {
+        char8 sensorName[SENSOR_NAME_MAX];
+        sensorMonitorFunc   sensor_handler;
+    };
 
-	struct sensorData snsrData[] =    {
-		{  "12v_pex\0"  ,V70_Asdm_Read_Current_12v},
-		{  "3v3_pex\0" ,V70_Asdm_Read_Current_3v3},
-		{  "vccint\0" ,V70_Asdm_Read_Current_Vccint}
-	};
+    struct sensorData snsrData[] =    {
+        {  "12v_pex\0"  ,V70_Asdm_Read_Current_12v},
+        {  "3v3_pex\0" ,V70_Asdm_Read_Current_3v3},
+        {  "vccint\0" ,V70_Asdm_Read_Current_Vccint}
+    };
 
-	if(NULL != snsrName)
-	{
-		Cl_SecureMemcpy(snsrName,SENSOR_NAME_MAX,&snsrData[index].sensorName[0],SENSOR_NAME_MAX);
+    if(NULL != snsrName)
+    {
+        Cl_SecureMemcpy(snsrName,SENSOR_NAME_MAX,&snsrData[index].sensorName[0],SENSOR_NAME_MAX);
 
-	}
-	else
-	{
-		return XST_FAILURE;
-	}
+    }
+    else
+    {
+        return XST_FAILURE;
+    }
 
-	*sensor_handler = snsrData[index].sensor_handler;
+    *sensor_handler = snsrData[index].sensor_handler;
 
-	return XST_SUCCESS;
+    return XST_SUCCESS;
 }
 s8 V70_Get_Voltage_Names(u8 index, char8* snsrName, u8 *sensorId,sensorMonitorFunc *sensor_handler)
 {
     struct sensorData
     {
         char8 sensorName[SENSOR_NAME_MAX];
-        sensorMonitorFunc	sensor_handler;
+        sensorMonitorFunc   sensor_handler;
     };
 
     struct sensorData voltageData[] =
@@ -478,7 +509,7 @@ s8 V70_Get_Voltage_Names(u8 index, char8* snsrName, u8 *sensorId,sensorMonitorFu
     }
     else
     {
-	return XST_FAILURE;
+    return XST_FAILURE;
     }
 
     *sensor_handler = voltageData[index].sensor_handler;
@@ -488,85 +519,83 @@ s8 V70_Get_Voltage_Names(u8 index, char8* snsrName, u8 *sensorId,sensorMonitorFu
 
 void V70_Monitor_Sensors()
 {
-//	snsrRead_t *snsrData = NULL;
+    /* Read Temp Sensors */
+//  V70_Temperature_Read_Inlet(snsrData);
+//  V70_Temperature_Read_Outlet(snsrData);
+    V70_Temperature_Monitor();
 
-	/* Read Temp Sensors */
-//	V70_Temperature_Read_Inlet(snsrData);
-//	V70_Temperature_Read_Outlet(snsrData);
-	V70_Temperature_Monitor();
+    /* Read Voltage Sensors */
+    V70_Voltage_Monitor_12V_PEX();
+    V70_Voltage_Monitor_3v3_PEX();
+    V70_Voltage_Monitor_3v3_AUX();
 
-	/* Read Voltage Sensors */
-	V70_Voltage_Monitor_12V_PEX();
-	V70_Voltage_Monitor_3v3_PEX();
-	V70_Voltage_Monitor_3v3_AUX();
+    /* Read Current Sensors */
+    V70_Current_Monitor_12V_PEX();
+    V70_Current_Monitor_3v3_PEX();
+    V70_Current_Monitor_Vccint();
 
-	/* Read Current Sensors */
-	V70_Current_Monitor_12V_PEX();
-	V70_Current_Monitor_3v3_PEX();
-	V70_Current_Monitor_Vccint();
-
-	/* Read Power Sensors */
-	V70_Power_Monitor();
+    /* Read Power Sensors */
+    V70_Power_Monitor();
 }
 static void v70_clk_scaling_params_init() {
 
-	g_clk_throttling_params.is_clk_scaling_supported = true;
-	g_clk_throttling_params.clk_scaling_mode = eCLK_SCALING_MODE_BOTH;
-	g_clk_throttling_params.clk_scaling_enable = false;
-	g_clk_throttling_params.limits.shutdown_limit_temp = V70_TEMP_FPGA_CRITICAL_THRESHOLD_LIMIT;
-	g_clk_throttling_params.limits.shutdown_limit_pwr = V70_POWER_CRITICAL_THRESHOLD_LIMIT;
-	g_clk_throttling_params.limits.throttle_limit_temp = V70_TEMP_THROTTLING_THRESHOLD_LIMIT;
-	g_clk_throttling_params.limits.throttle_limit_pwr = V70_POWER_THROTTLING_THRESHOLD_LIMIT;
-	return;
+    g_clk_throttling_params.is_clk_scaling_supported = true;
+    g_clk_throttling_params.clk_scaling_mode = eCLK_SCALING_MODE_BOTH;
+    g_clk_throttling_params.clk_scaling_enable = false;
+    g_clk_throttling_params.limits.shutdown_limit_temp = V70_TEMP_FPGA_CRITICAL_THRESHOLD_LIMIT;
+    g_clk_throttling_params.limits.shutdown_limit_pwr = V70_POWER_CRITICAL_THRESHOLD_LIMIT;
+    g_clk_throttling_params.limits.throttle_limit_temp = V70_TEMP_THROTTLING_THRESHOLD_LIMIT;
+    g_clk_throttling_params.limits.throttle_limit_pwr = V70_POWER_THROTTLING_THRESHOLD_LIMIT;
+    return;
 }
 void Build_clock_throttling_profile_V70(Clock_Throttling_Profile_t * pProfile)
 {
-	pProfile->NumberOfSensors = V70_NUM_POWER_RAILS;
+    pProfile->NumberOfSensors = V70_NUM_POWER_RAILS;
 
-	pProfile->VoltageSensorID[0] = e12V_PEX;
-	pProfile->VoltageSensorID[1] = e3V3_PEX;
+    pProfile->VoltageSensorID[0] = e12V_PEX;
+    pProfile->VoltageSensorID[1] = e3V3_PEX;
 
-	pProfile->CurrentSensorID[0] = e12V_PEX;
-	pProfile->CurrentSensorID[1] = e3V3_PEX;
+    pProfile->CurrentSensorID[0] = e12V_PEX;
+    pProfile->CurrentSensorID[1] = e3V3_PEX;
 
-	pProfile->throttlingThresholdCurrent[0] = V70_PEX_12V_I_IN_THROTTLING_LIMIT;
-	pProfile->throttlingThresholdCurrent[1] = V70_PEX_3V3_I_IN_THROTTLING_LIMIT;
+    pProfile->throttlingThresholdCurrent[0] = V70_PEX_12V_I_IN_THROTTLING_LIMIT;
+    pProfile->throttlingThresholdCurrent[1] = V70_PEX_3V3_I_IN_THROTTLING_LIMIT;
 
-	pProfile->NominalVoltage[0] = NOMINAL_VOLTAGE_12V_IN_MV;
-	pProfile->NominalVoltage[1] = NOMINAL_VOLTAGE_3V3_IN_MV;
-	pProfile->IdlePower = V70_IDLE_POWER;
+    pProfile->NominalVoltage[0] = NOMINAL_VOLTAGE_12V_IN_MV;
+    pProfile->NominalVoltage[1] = NOMINAL_VOLTAGE_3V3_IN_MV;
+    pProfile->IdlePower = V70_IDLE_POWER;
 
-	pProfile->FPGATempThrottlingLimit = V70_FPGA_THROTTLING_TEMP_LIMIT;
-	pProfile->VccIntTempThrottlingLimit = V70_FPGA_THROTTLING_TEMP_LIMIT;
-	pProfile->PowerThrottlingLimit = V70_POWER_THROTTLING_THRESHOLD_LIMIT;
+    pProfile->FPGATempThrottlingLimit = V70_FPGA_THROTTLING_TEMP_LIMIT;
+    pProfile->VccIntTempThrottlingLimit = V70_FPGA_THROTTLING_TEMP_LIMIT;
+    pProfile->PowerThrottlingLimit = V70_POWER_THROTTLING_THRESHOLD_LIMIT;
 
-	pProfile->bVCCIntThermalThrottling = true;
-	pProfile->TempGainKpFPGA    = V70_TEMP_GAIN_KP_FPGA;
-	pProfile->TempGainKi        = V70_TEMP_GAIN_KI;
-	pProfile->TempGainKpVCCInt  = V70_TEMP_GAIN_KP_VCCINT;
-	pProfile->TempGainKaw       = V70_TEMP_GAIN_KAW;
+    pProfile->bVCCIntThermalThrottling = true;
+    pProfile->TempGainKpFPGA    = V70_TEMP_GAIN_KP_FPGA;
+    pProfile->TempGainKi        = V70_TEMP_GAIN_KI;
+    pProfile->TempGainKpVCCInt  = V70_TEMP_GAIN_KP_VCCINT;
+    pProfile->TempGainKaw       = V70_TEMP_GAIN_KAW;
 
-	pProfile->IntegrataionSumInitial = V70_INTEGRATION_SUM_INITIAL;
+    pProfile->IntegrataionSumInitial = V70_INTEGRATION_SUM_INITIAL;
 
 }
 u8 V70_Init(void)
 {
-	//s8 status = XST_FAILURE;
-	msg_id_handler_ptr = V70_VMC_SC_Comms_Msg;
-	set_total_req_size(V70_MAX_MSGID_COUNT);
-	fetch_boardinfo_ptr = &V70_VMC_Fetch_BoardInfo;
-	
-	Monitor_Sensors = V70_Monitor_Sensors;
+    //s8 status = XST_FAILURE;
+    msg_id_handler_ptr = V70_VMC_SC_Comms_Msg;
+    set_total_req_size(V70_MAX_MSGID_COUNT);
+    fetch_boardinfo_ptr = &V70_VMC_Fetch_BoardInfo;
+    
+    Monitor_Sensors = V70_Monitor_Sensors;
 
-	v70_clk_scaling_params_init();
+    v70_clk_scaling_params_init();
 
-	/* platform specific initialization */
-	Build_clock_throttling_profile_V70(&clock_throttling_v70);
+    /* platform specific initialization */
+    Build_clock_throttling_profile_V70(&clock_throttling_v70);
 
-	/* clock throttling initialization */
-	ClockThrottling_Initialize(&clock_throttling_std_algorithm, &clock_throttling_v70);
+    /* clock throttling initialization */
+    ClockThrottling_Initialize(&clock_throttling_std_algorithm, &clock_throttling_v70);
 
-	get_supported_sdr_info = V70_Get_Supported_Sdr_Info;
-	asdm_update_record_count = V70_Asdm_Update_Record_Count;
-	return XST_SUCCESS;
+    get_supported_sdr_info = V70_Get_Supported_Sdr_Info;
+    asdm_update_record_count = V70_Asdm_Update_Record_Count;
+    return XST_SUCCESS;
 }

--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -13,22 +13,22 @@
 
 #define ASDM_GET_SDR_SIZE_REQ (0x00)
 
-#define SENSOR_TYPE_NUM	(0x0)
-#define SENSOR_TYPE_ASCII	(0xC << 4)
+#define SENSOR_TYPE_NUM (0x0)
+#define SENSOR_TYPE_ASCII   (0xC << 4)
 
-#define SENSOR_SIZE_1B	(0x1)
-#define SENSOR_SIZE_2B	(0x2)
-#define SENSOR_SIZE_4B	(0x4)
+#define SENSOR_SIZE_1B  (0x1)
+#define SENSOR_SIZE_2B  (0x2)
+#define SENSOR_SIZE_4B  (0x4)
 
-#define NO_THRESHOLDS	(0x0)
-#define SNSR_MAX_VAL	(0x1 << 7)
-#define SNSR_AVG_VAL	(0x1 << 6)
-#define HAS_LOWER_THRESHOLDS	(0x7 << 3)
-#define HAS_UPPER_THRESHOLDS	(0x7)
+#define NO_THRESHOLDS   (0x0)
+#define SNSR_MAX_VAL    (0x1 << 7)
+#define SNSR_AVG_VAL    (0x1 << 6)
+#define HAS_LOWER_THRESHOLDS    (0x7 << 3)
+#define HAS_UPPER_THRESHOLDS    (0x7)
 
 #define LENGTH_BITMASK   (0x3F)
-#define SENSOR_REPOSITORY_REQUEST	(0xF1)
-#define THRESHOLDS_UNSUPPORTED	(0x00)
+#define SENSOR_REPOSITORY_REQUEST   (0xF1)
+#define THRESHOLDS_UNSUPPORTED  (0x00)
 
 #define QSFP_MAX_NUM    (2)
 
@@ -45,16 +45,16 @@
 #define VCCINT_NAME    "vccint\0"
 
 /* ASDM API Req/Resp Offsets */
-#define ASDM_REQ_BYTE_CMD_CODE		(0)
-#define ASDM_REQ_BYTE_REPO_TYPE		(1)
-#define ASDM_REQ_BYTE_SNSR_ID		(2)
+#define ASDM_REQ_BYTE_CMD_CODE      (0)
+#define ASDM_REQ_BYTE_REPO_TYPE     (1)
+#define ASDM_REQ_BYTE_SNSR_ID       (2)
 
 /* CC - Completion Code */
-#define ASDM_RESP_BYTE_CC		(0)
-#define ASDM_RESP_BYTE_REPO_TYPE	(1)
-#define ASDM_RESP_BYTE_SNSR_SIZE	(2)
+#define ASDM_RESP_BYTE_CC       (0)
+#define ASDM_RESP_BYTE_REPO_TYPE    (1)
+#define ASDM_RESP_BYTE_SNSR_SIZE    (2)
 
-#define MAX_SDR_INFO_COUNT		(100)
+#define MAX_SDR_INFO_COUNT      (100)
 
 SDR_t *sdrInfo;
 extern SemaphoreHandle_t sdr_lock;
@@ -92,22 +92,22 @@ asdm_update_record_count_ptr asdm_update_record_count;
 
 Asdm_Sensor_Thresholds_t thresholds_limit_tbl[]= {
     /*  Name           LW   LC   LF    UW   UC  UF  */
-    { TEMP_BOARD_NAME,	0,   0,  0,     80,  85, 95 },
-    { TEMP_ACAP_NAME,	0,   0,  0,     88,  97, 107 },
-    { TEMP_VCCINT_NAME,	0,   0,  0,     100, 110, 125 },
+    { TEMP_BOARD_NAME,  0,   0,  0,     80,  85, 95 },
+    { TEMP_ACAP_NAME,   0,   0,  0,     88,  97, 107 },
+    { TEMP_VCCINT_NAME, 0,   0,  0,     100, 110, 125 },
     { TEMP_CAGE0_NAME,  0,   0,  0,     80,  85, 90 },
     { TEMP_CAGE1_NAME,  0,   0,  0,     80,  85, 90 },
 
 };
 
 Asdm_Sensor_Unit_t sensor_unit_tbl[] = {
-	[BoardInfoSDR]   = { 0x0 , "NA" },
-	[TemperatureSDR] = { 0xC8, "Celsius\0" },
-	[VoltageSDR]     = { 0xC6, "Volts\0" },
-	[CurrentSDR]     = { 0xC5, "Amps\0" },
-	[PowerSDR]       = { 0xC6, "Watts\0" },
+    [BoardInfoSDR]   = { 0x0 , "NA" },
+    [TemperatureSDR] = { 0xC8, "Celsius\0" },
+    [VoltageSDR]     = { 0xC6, "Volts\0" },
+    [CurrentSDR]     = { 0xC5, "Amps\0" },
+    [PowerSDR]       = { 0xC6, "Watts\0" },
 };
-#define THRESHOLD_TBL_SIZE 	(sizeof(thresholds_limit_tbl)/sizeof(thresholds_limit_tbl[0]))
+#define THRESHOLD_TBL_SIZE  (sizeof(thresholds_limit_tbl)/sizeof(thresholds_limit_tbl[0]))
 
 
 
@@ -115,15 +115,15 @@ Asdm_Sensor_Unit_t sensor_unit_tbl[] = {
  * Record Count is updated based on Platform Type runtime
  */
 Asdm_Header_t asdmHeaderInfo[] = {
-    /* Record Type	| Hdr Version | Record Count | NumBytes */
-    {BoardInfoSDR ,  	ASDM_HEADER_VER,  0, 	0x7f},
-    {TemperatureSDR, 	ASDM_HEADER_VER,  0,	0x7f},
-    {VoltageSDR,  	ASDM_HEADER_VER,  0, 	0x7f},
-    {CurrentSDR, 	ASDM_HEADER_VER,  0,	0x7f},
-    {PowerSDR, 		ASDM_HEADER_VER,  0,	0x7f},
+    /* Record Type  | Hdr Version | Record Count | NumBytes */
+    {BoardInfoSDR ,     ASDM_HEADER_VER,  0,    0x7f},
+    {TemperatureSDR,    ASDM_HEADER_VER,  0,    0x7f},
+    {VoltageSDR,    ASDM_HEADER_VER,  0,    0x7f},
+    {CurrentSDR,    ASDM_HEADER_VER,  0,    0x7f},
+    {PowerSDR,      ASDM_HEADER_VER,  0,    0x7f},
 };
 
-#define MAX_SDR_REPO 	(sizeof(asdmHeaderInfo)/sizeof(asdmHeaderInfo[0]))
+#define MAX_SDR_REPO    (sizeof(asdmHeaderInfo)/sizeof(asdmHeaderInfo[0]))
 
 /****************************************************************
  * Note:-
@@ -138,53 +138,53 @@ Asdm_Header_t asdmHeaderInfo[] = {
 void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
 {
     Asdm_Sensor_MetaData_t snsrMetaData[eSdr_Sensor_Max] = {
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "Product Name\0",
-	    .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.product_name),
-	    .defaultValue = &board_info.product_name[0],
-	},
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "Serial Num\0",
-	    .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.board_serial),
-	    .defaultValue = &board_info.board_serial[0],
-	},
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "Part Num\0",
-	    .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.board_part_num),
-	    .defaultValue = &board_info.board_part_num[0],
-	},
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "Revision\0",
-	    .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.board_rev),
-	    .defaultValue = &board_info.board_rev[0],
-	},
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "MFG Date\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_mfg_date),
-	    .defaultValue = &board_info.board_mfg_date[0],
-	},
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "UUID\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_uuid),
-	    .defaultValue = &board_info.board_uuid[0],
-	},
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "MAC 0\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_mac[0]),
-	    .defaultValue = board_info.board_mac[0],
-	},
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "MAC 1\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_mac[1]),
-	    .defaultValue = board_info.board_mac[1],
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "Product Name\0",
+        .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.product_name),
+        .defaultValue = &board_info.product_name[0],
+    },
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "Serial Num\0",
+        .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.board_serial),
+        .defaultValue = &board_info.board_serial[0],
+    },
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "Part Num\0",
+        .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.board_part_num),
+        .defaultValue = &board_info.board_part_num[0],
+    },
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "Revision\0",
+        .snsrValTypeLength = SENSOR_TYPE_ASCII | sizeof(board_info.board_rev),
+        .defaultValue = &board_info.board_rev[0],
+    },
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "MFG Date\0",
+        .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_mfg_date),
+        .defaultValue = &board_info.board_mfg_date[0],
+    },
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "UUID\0",
+        .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_uuid),
+        .defaultValue = &board_info.board_uuid[0],
+    },
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "MAC 0\0",
+        .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_mac[0]),
+        .defaultValue = board_info.board_mac[0],
+    },
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "MAC 1\0",
+        .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.board_mac[1]),
+        .defaultValue = board_info.board_mac[1],
         },
     {
         .repoType = BoardInfoSDR,
@@ -204,101 +204,101 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
         .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(fpt_sc_version),
         .defaultValue = &fpt_sc_version[0],
     },
-	{
-	    .repoType = BoardInfoSDR,
-	    .sensorName = "OEM ID\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.OEM_ID),
-	    .defaultValue = &board_info.OEM_ID[0],
-	},
-	{
-	    .repoType = TemperatureSDR,
-	    .sensorName = TEMP_BOARD_NAME,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
-	    .snsrUnitModifier = 0x0,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
-	    .sampleCount = 0x1,
-	    .sensorListTbl = eSC_BOARD_TEMP,
-	    .monitorFunc = &Temperature_Read_Board,
-	},
-	{
-	    .repoType = TemperatureSDR,
-	    .sensorName = TEMP_ACAP_NAME,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
-	    .snsrUnitModifier = 0x0,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
-	    .sampleCount = 0x1,
-	    .sensorListTbl = eSC_FPGA_TEMP,
-	    .monitorFunc = &Temperature_Read_ACAP_Device_Sysmon,
-	},
-	{
-	    .repoType = TemperatureSDR,
-	    .sensorName = TEMP_VCCINT_NAME,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
-	    .snsrUnitModifier = 0x0,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
-	    .sampleCount = 0x1,
-	    .sensorListTbl = eSC_VCCINT_TEMP,
-	    .monitorFunc = &Temperature_Read_VCCINT,
-	},
-	{
-	    .repoType = TemperatureSDR,
-	    .getSensorName = &getQSFPName,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
-	    .snsrUnitModifier = 0x0,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
-	    .sampleCount = 0x1,
-	    .sensorInstance = QSFP_MAX_NUM,
-	    .monitorFunc = NULL,
-	},
-	{
-	    .repoType = VoltageSDR,
-	    .getSensorName = &getVoltagesName,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
-	    .snsrUnitModifier = -3,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
-	    .sampleCount = 0x1,
-	    .sensorInstance = getVoltageSensorNum(),
-	    .monitorFunc = NULL,
-	},
-	{
-		.repoType = VoltageSDR,
-		.sensorName = VCCINT_NAME,
-		.snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
-		.snsrUnitModifier = -3,
-		.supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
-		.sampleCount = 0x1,
-		.sensorListTbl = VCCINT,
-		.monitorFunc = &VCCINT_Read_ACAP_Device_Sysmon,
-	},
-	{
-	    .repoType = CurrentSDR,
-	    .getSensorName = &getCurrentNames,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
-	    .snsrUnitModifier = -3,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
-	    .sampleCount = 0x1,
-	    .sensorInstance = getCurrentSensorNum(),
-	    .monitorFunc = NULL,
-	},
-	{
-	    .repoType = CurrentSDR,
-	    .sensorName = VCCINT_NAME,
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
-	    .snsrUnitModifier = -3,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
-	    .sampleCount = 0x1,
-	    .sensorListTbl = eSC_VCCINT_I,
-	    .monitorFunc = &PMBUS_SC_Vccint_Read,
-	},
-	{
-	    .repoType = PowerSDR,
-	    .sensorName = "Total Power\0",
-	    .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
-	    .snsrUnitModifier = 0,
-	    .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
-	    .sampleCount = 0x1,
-	    .monitorFunc = &Asdm_Read_Power,
-	},
+    {
+        .repoType = BoardInfoSDR,
+        .sensorName = "OEM ID\0",
+        .snsrValTypeLength = SENSOR_TYPE_NUM | sizeof(board_info.OEM_ID),
+        .defaultValue = &board_info.OEM_ID[0],
+    },
+    {
+        .repoType = TemperatureSDR,
+        .sensorName = TEMP_BOARD_NAME,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrUnitModifier = 0x0,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
+        .sampleCount = 0x1,
+        .sensorListTbl = eSC_BOARD_TEMP,
+        .monitorFunc = &Temperature_Read_Board,
+    },
+    {
+        .repoType = TemperatureSDR,
+        .sensorName = TEMP_ACAP_NAME,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrUnitModifier = 0x0,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
+        .sampleCount = 0x1,
+        .sensorListTbl = eSC_FPGA_TEMP,
+        .monitorFunc = &Temperature_Read_ACAP_Device_Sysmon,
+    },
+    {
+        .repoType = TemperatureSDR,
+        .sensorName = TEMP_VCCINT_NAME,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrUnitModifier = 0x0,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
+        .sampleCount = 0x1,
+        .sensorListTbl = eSC_VCCINT_TEMP,
+        .monitorFunc = &Temperature_Read_VCCINT,
+    },
+    {
+        .repoType = TemperatureSDR,
+        .getSensorName = &getQSFPName,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrUnitModifier = 0x0,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL | HAS_UPPER_THRESHOLDS,
+        .sampleCount = 0x1,
+        .sensorInstance = QSFP_MAX_NUM,
+        .monitorFunc = NULL,
+    },
+    {
+        .repoType = VoltageSDR,
+        .getSensorName = &getVoltagesName,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrUnitModifier = -3,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
+        .sampleCount = 0x1,
+        .sensorInstance = getVoltageSensorNum(),
+        .monitorFunc = NULL,
+    },
+    {
+        .repoType = VoltageSDR,
+        .sensorName = VCCINT_NAME,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
+        .snsrUnitModifier = -3,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
+        .sampleCount = 0x1,
+        .sensorListTbl = VCCINT,
+        .monitorFunc = &VCCINT_Read_ACAP_Device_Sysmon,
+    },
+    {
+        .repoType = CurrentSDR,
+        .getSensorName = &getCurrentNames,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrUnitModifier = -3,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
+        .sampleCount = 0x1,
+        .sensorInstance = getCurrentSensorNum(),
+        .monitorFunc = NULL,
+    },
+    {
+        .repoType = CurrentSDR,
+        .sensorName = VCCINT_NAME,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
+        .snsrUnitModifier = -3,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
+        .sampleCount = 0x1,
+        .sensorListTbl = eSC_VCCINT_I,
+        .monitorFunc = &PMBUS_SC_Vccint_Read,
+    },
+    {
+        .repoType = PowerSDR,
+        .sensorName = "Total Power\0",
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrUnitModifier = 0,
+        .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
+        .sampleCount = 0x1,
+        .monitorFunc = &Asdm_Read_Power,
+    },
     };
 
 
@@ -306,60 +306,60 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
     u32 platform_Supported_Sensors[MAX_SDR_INFO_COUNT] = {0};
 
     if(NULL != get_supported_sdr_info) {
-    	(*get_supported_sdr_info)(platform_Supported_Sensors,&sdr_count);
-    	*sdrMetaDataCount = sdr_count;
+        (*get_supported_sdr_info)(platform_Supported_Sensors,&sdr_count);
+        *sdrMetaDataCount = sdr_count;
     }
 
     *pMetaData = (Asdm_Sensor_MetaData_t *) pvPortMalloc( sizeof(Asdm_Sensor_MetaData_t) * (*sdrMetaDataCount));
     if(*pMetaData != NULL)
     {
-    	Cl_SecureMemset(*pMetaData,0x00,(sizeof(Asdm_Sensor_MetaData_t) * (*sdrMetaDataCount)));
+        Cl_SecureMemset(*pMetaData,0x00,(sizeof(Asdm_Sensor_MetaData_t) * (*sdrMetaDataCount)));
 
-    	u16 loop = 0;
-    	u32 offset = 0;
-    	u32 sensorPdrIndex = 0;
-    	for(loop = 0; loop < (*sdrMetaDataCount); loop++)
-    	{
-    		sensorPdrIndex = platform_Supported_Sensors[loop];
-    		Cl_SecureMemcpy(*(pMetaData)+loop,sizeof(Asdm_Sensor_MetaData_t),
-    				&snsrMetaData[sensorPdrIndex], sizeof(Asdm_Sensor_MetaData_t));
-    		offset += sizeof(Asdm_Sensor_MetaData_t);
-    	}
+        u16 loop = 0;
+        u32 offset = 0;
+        u32 sensorPdrIndex = 0;
+        for(loop = 0; loop < (*sdrMetaDataCount); loop++)
+        {
+            sensorPdrIndex = platform_Supported_Sensors[loop];
+            Cl_SecureMemcpy(*(pMetaData)+loop,sizeof(Asdm_Sensor_MetaData_t),
+                    &snsrMetaData[sensorPdrIndex], sizeof(Asdm_Sensor_MetaData_t));
+            offset += sizeof(Asdm_Sensor_MetaData_t);
+        }
     }
     else
     {
-    	VMC_ERR(" pvPortMalloc Failed\n\r");
-    	return;
+        VMC_ERR(" pvPortMalloc Failed\n\r");
+        return;
     }
 
 }
 
 u8 getThresholdIdx(u8 *threshIdx,char8 *snsrName,u8 snsrNameLen)
 {
-	u8 i=0;
-	for(i=0; i<THRESHOLD_TBL_SIZE; i++)
-	{
-		if(!Cl_SecureStrncmp(snsrName,snsrNameLen-2,thresholds_limit_tbl[i].sensorName,snsrNameLen-2))
-		{
-			*threshIdx = i;
-			break;
-		}
-	}
-	return 0;
+    u8 i=0;
+    for(i=0; i<THRESHOLD_TBL_SIZE; i++)
+    {
+        if(!Cl_SecureStrncmp(snsrName,snsrNameLen-2,thresholds_limit_tbl[i].sensorName,snsrNameLen-2))
+        {
+            *threshIdx = i;
+            break;
+        }
+    }
+    return 0;
 }
 
 u8 isRepoTypeSupported(u32 sensorType)
 {
-	u8 i=0;
+    u8 i=0;
 
-	for(i=0;i<MAX_SDR_REPO;i++)
-	{
-		if(asdmHeaderInfo[i].repository_type == sensorType)
-		{
-			return true;
-		}
-	}
-	return false;
+    for(i=0;i<MAX_SDR_REPO;i++)
+    {
+        if(asdmHeaderInfo[i].repository_type == sensorType)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 /*
@@ -375,17 +375,17 @@ u8 isRepoTypeSupported(u32 sensorType)
  */
 s8 getSDRIndex(u8 repoType)
 {
-	s8 i=-1;
+    s8 i=-1;
 
-	for(i=0;i<MAX_SDR_REPO;i++)
-	{
-		if(asdmHeaderInfo[i].repository_type == repoType)
-		{
-			return i;
-		}
-	}
+    for(i=0;i<MAX_SDR_REPO;i++)
+    {
+        if(asdmHeaderInfo[i].repository_type == repoType)
+        {
+            return i;
+        }
+    }
 
-	return i;
+    return i;
 }
 
 u8 Update_Sensor_Value(Asdm_RepositoryTypeEnum_t repoType, u8 sensorIdx, snsrRead_t *snsrInfo)
@@ -397,74 +397,70 @@ u8 Update_Sensor_Value(Asdm_RepositoryTypeEnum_t repoType, u8 sensorIdx, snsrRea
 
     if(NULL != sensorRecord)
     {
-	if (xSemaphoreTake(sdr_lock, portMAX_DELAY))
-	{
-	  if( (0 != snsrInfo->sensorValueSize) && (NULL != &sensorRecord->sensor_value) ){
-	    Cl_SecureMemcpy(sensorRecord->sensor_value,snsrInfo->sensorValueSize,&snsrInfo->snsrValue[0],snsrInfo->sensorValueSize);
-	  }
-	    /* Update only if the sensor is not Static */
-	    if(sensorRecord->sampleCount > 0)
-	    {
-		/* Update Sensor Status */
-		sensorRecord->sensor_status = snsrInfo->snsrSatus;
+        if( (0 != snsrInfo->sensorValueSize) && (NULL != &sensorRecord->sensor_value) ){
+            Cl_SecureMemcpy(sensorRecord->sensor_value,snsrInfo->sensorValueSize,&snsrInfo->snsrValue[0],snsrInfo->sensorValueSize);
+        }
+        /* Update only if the sensor is not Static */
+        if(sensorRecord->sampleCount > 0)
+        {
+            /* Update Sensor Status */
+            sensorRecord->sensor_status = snsrInfo->snsrSatus;
 
-		if(snsrInfo->sensorValueSize == sizeof(u32))
-		{
-			/* Update Max Sensor Value */
-			if ( *((u32 *)sensorRecord->sensor_value) > *((u32 *)sensorRecord->sensorMaxValue))
-			{
-				Cl_SecureMemcpy(sensorRecord->sensorMaxValue,snsrInfo->sensorValueSize,sensorRecord->sensor_value,
-				    snsrInfo->sensorValueSize);
-			}
+            /*
+            * Only update average value if we have a valid sensor read.
+            * */
+            if(sensorRecord->sensor_status == Vmc_Snsr_State_Normal)
+            {
+                if(snsrInfo->sensorValueSize == sizeof(u32))
+                {
+                    /* Update Max Sensor Value */
+                    if ( *((u32 *)sensorRecord->sensor_value) > *((u32 *)sensorRecord->sensorMaxValue))
+                    {
+                        Cl_SecureMemcpy(sensorRecord->sensorMaxValue,snsrInfo->sensorValueSize,sensorRecord->sensor_value,
+                        snsrInfo->sensorValueSize);
+                    }
+                    /* Calculate and Update Average Value */
+                    *((u32 *)sensorRecord->sensorAverageValue) = *((u32 *)sensorRecord->sensorAverageValue)
+                                - (*((u32 *)sensorRecord->sensorAverageValue)/sensorRecord->sampleCount)
+                                + (*((u32 *)sensorRecord->sensor_value)/sensorRecord->sampleCount);
+                }
+                else if(snsrInfo->sensorValueSize == sizeof(u16))
+                {
+                    /* Update Max Sensor Value */
+                    if ( *((u16 *)sensorRecord->sensor_value) > *((u16 *)sensorRecord->sensorMaxValue))
+                    {
+                        Cl_SecureMemcpy(sensorRecord->sensorMaxValue,snsrInfo->sensorValueSize,sensorRecord->sensor_value,
+                        snsrInfo->sensorValueSize);
+                    }
 
-			/* Calculate and Update Average Value */
-			*((u32 *)sensorRecord->sensorAverageValue) = *((u32 *)sensorRecord->sensorAverageValue)
-			    				- (*((u32 *)sensorRecord->sensorAverageValue)/sensorRecord->sampleCount)
-			    				+ (*((u32 *)sensorRecord->sensor_value)/sensorRecord->sampleCount);
-		}
-		else if(snsrInfo->sensorValueSize == sizeof(u16))
-		{
-			/* Update Max Sensor Value */
-			if ( *((u16 *)sensorRecord->sensor_value) > *((u16 *)sensorRecord->sensorMaxValue))
-			{
-				Cl_SecureMemcpy(sensorRecord->sensorMaxValue,snsrInfo->sensorValueSize,sensorRecord->sensor_value,
-						snsrInfo->sensorValueSize);
-			}
+                    /* Calculate and Update Average Value */
+                    *((u16 *)sensorRecord->sensorAverageValue) = (*((u16 *)sensorRecord->sensorAverageValue)
+                            - (*((u16 *)sensorRecord->sensorAverageValue)/sensorRecord->sampleCount))
+                            + (*((u16 *)sensorRecord->sensor_value)/sensorRecord->sampleCount);
+                }
+                else if(snsrInfo->sensorValueSize == sizeof(u8))
+                {
+                    /* Update Max Sensor Value */
+                    if ( *((u8 *)sensorRecord->sensor_value) > *((u8 *)sensorRecord->sensorMaxValue))
+                    {
+                        Cl_SecureMemcpy(sensorRecord->sensorMaxValue,snsrInfo->sensorValueSize,sensorRecord->sensor_value,
+                        snsrInfo->sensorValueSize);
+                    }
 
-			/* Calculate and Update Average Value */
-			*((u16 *)sensorRecord->sensorAverageValue) = (*((u16 *)sensorRecord->sensorAverageValue)
-					    				- (*((u16 *)sensorRecord->sensorAverageValue)/sensorRecord->sampleCount))
-									+ (*((u16 *)sensorRecord->sensor_value)/sensorRecord->sampleCount);
-		}
-		else if(snsrInfo->sensorValueSize == sizeof(u8))
-		{
-			/* Update Max Sensor Value */
-			if ( *((u8 *)sensorRecord->sensor_value) > *((u8 *)sensorRecord->sensorMaxValue))
-			{
-				Cl_SecureMemcpy(sensorRecord->sensorMaxValue,snsrInfo->sensorValueSize,sensorRecord->sensor_value,
-						snsrInfo->sensorValueSize);
-			}
-
-			/* Calculate and Update Average Value */
-			*((u8 *)sensorRecord->sensorAverageValue) = (*((u8 *)sensorRecord->sensorAverageValue)
-					    				- (*((u8 *)sensorRecord->sensorAverageValue)/sensorRecord->sampleCount))
-									+ (*((u8 *)sensorRecord->sensor_value)/sensorRecord->sampleCount);
-		}
-		/* Increment the Sample Count after a Successful read*/
-		sensorRecord->sampleCount++;
-	    }
-	    xSemaphoreGive(sdr_lock);
-	}
-	else
-	{
-	    VMC_ERR("Failed to Acquire sdr lock\n\r");
-	    return -1;
-	}
+                    /* Calculate and Update Average Value */
+                    *((u8 *)sensorRecord->sensorAverageValue) = (*((u8 *)sensorRecord->sensorAverageValue)
+                            - (*((u8 *)sensorRecord->sensorAverageValue)/sensorRecord->sampleCount))
+                            + (*((u8 *)sensorRecord->sensor_value)/sensorRecord->sampleCount);
+                }
+                /* Increment the Sample Count after a Successful read*/
+                sensorRecord->sampleCount++;
+            }
+        }
     }
     else
     {
-	VMC_ERR("InValid SDR Data\n\r");
-	return -1;
+        VMC_ERR("InValid SDR Data\n\r");
+        return -1;
     }
 
     return 0;
@@ -491,7 +487,7 @@ s8 Init_Asdm()
     /* Update the Platform specific Record Count*/
     if(asdm_update_record_count != NULL)
     {
-    	(*asdm_update_record_count)(asdmHeaderInfo);
+        (*asdm_update_record_count)(asdmHeaderInfo);
     }
     /* Fetch the ASDM SDR Repository */
     getSDRMetaData(&pSdrMetaData, &sdrMetaDataCount);
@@ -499,15 +495,15 @@ s8 Init_Asdm()
     /* Validation check if SDR Data Count is Valid */
     while(idx < MAX_SDR_REPO)
     {
-	totalRecords += asdmHeaderInfo[idx].no_of_records;
-	idx++;
+        totalRecords += asdmHeaderInfo[idx].no_of_records;
+        idx++;
     }
 
     if(sdrMetaDataCount != totalRecords)
     {
-	/* LoG Error, don't proceed for Init */
-	//VMC_ERR("Records Count Mismatch  !!!\n\r");
-	//return -1;
+        /* LoG Error, don't proceed for Init */
+        //VMC_ERR("Records Count Mismatch  !!!\n\r");
+        //return -1;
     }
 
     /* for future use */
@@ -515,313 +511,312 @@ s8 Init_Asdm()
 
     if(pSdrMetaData != NULL)
     {
-	/* Allocate Memory for Number of Repo Type */
-	sdrInfo = (SDR_t *) pvPortMalloc(MAX_SDR_REPO * sizeof(SDR_t));
-	if(sdrInfo == NULL)
-	{
-	    VMC_ERR("Failed to allocate Memory for SDR !!!\n\r");
-	    return -1;
-	}
-	Cl_SecureMemset(sdrInfo,0x00,(MAX_SDR_REPO * sizeof(SDR_t)));
+        /* Allocate Memory for Number of Repo Type */
+        sdrInfo = (SDR_t *) pvPortMalloc(MAX_SDR_REPO * sizeof(SDR_t));
+        if(sdrInfo == NULL)
+        {
+            VMC_ERR("Failed to allocate Memory for SDR !!!\n\r");
+            return -1;
+        }
+        Cl_SecureMemset(sdrInfo,0x00,(MAX_SDR_REPO * sizeof(SDR_t)));
 
-	for(sdrCount = 0; sdrCount < MAX_SDR_REPO; sdrCount++)
-	{
-	    /* Fill ASDM Header */
-	    sdrInfo[sdrCount].header.repository_type = asdmHeaderInfo[sdrCount].repository_type;
-	    sdrInfo[sdrCount].header.repository_version = asdmHeaderInfo[sdrCount].repository_version;
-	    sdrInfo[sdrCount].header.no_of_records = asdmHeaderInfo[sdrCount].no_of_records;
-	    sdrInfo[sdrCount].header.no_of_bytes = asdmHeaderInfo[sdrCount].no_of_bytes;
+        for(sdrCount = 0; sdrCount < MAX_SDR_REPO; sdrCount++)
+        {
+            /* Fill ASDM Header */
+            sdrInfo[sdrCount].header.repository_type = asdmHeaderInfo[sdrCount].repository_type;
+            sdrInfo[sdrCount].header.repository_version = asdmHeaderInfo[sdrCount].repository_version;
+            sdrInfo[sdrCount].header.no_of_records = asdmHeaderInfo[sdrCount].no_of_records;
+            sdrInfo[sdrCount].header.no_of_bytes = asdmHeaderInfo[sdrCount].no_of_bytes;
 
-	    /* Based on Number of Records allocate memory of Sensor Records*/
-	    allocateSize = sizeof(Asdm_SensorRecord_t) * asdmHeaderInfo[sdrCount].no_of_records;
-	    sdrInfo[sdrCount].sensorRecord = (Asdm_SensorRecord_t *)pvPortMalloc(allocateSize);
-	    if(NULL == sdrInfo[sdrCount].sensorRecord)
-	    {
-		VMC_ERR("Failed to allocate Memory for SDR Record !!!\n\r");
-		return -1;
-	    }
+            /* Based on Number of Records allocate memory of Sensor Records*/
+            allocateSize = sizeof(Asdm_SensorRecord_t) * asdmHeaderInfo[sdrCount].no_of_records;
+            sdrInfo[sdrCount].sensorRecord = (Asdm_SensorRecord_t *)pvPortMalloc(allocateSize);
+            if(NULL == sdrInfo[sdrCount].sensorRecord)
+            {
+                VMC_ERR("Failed to allocate Memory for SDR Record !!!\n\r");
+                return -1;
+            }
 
-	    Cl_SecureMemset(sdrInfo[sdrCount].sensorRecord,0x00,allocateSize);
+            Cl_SecureMemset(sdrInfo[sdrCount].sensorRecord,0x00,allocateSize);
 
-	    Asdm_SensorRecord_t *tmp = sdrInfo[sdrCount].sensorRecord;
-	    currentRepoType = asdmHeaderInfo[sdrCount].repository_type;
+            Asdm_SensorRecord_t *tmp = sdrInfo[sdrCount].sensorRecord;
+            currentRepoType = asdmHeaderInfo[sdrCount].repository_type;
 
-	    byteCount = 0;
-	    /* Initialize each Sensor Info, idx incremented below */
-	    for(idx = 0; idx < asdmHeaderInfo[sdrCount].no_of_records; )
-	    {
-		totalSensorInstances = pSdrMetaData[totalRecords].sensorInstance;
-		/* By default totalSensorInstance is considered as 1,
-		 * even if its uninitialized
-		 */
-		totalSensorInstances = (totalSensorInstances <= 1) ? 1 : totalSensorInstances;
-		/* If Sensor Instance > 1, initialize it in loop */
-		sensorInstance = 0;
-		while(sensorInstance < totalSensorInstances)
-		{
-		/* Assign  the Sensor Id Count for this RepoType  */
-		tmp[idx].sensor_id = idx + 1;
-		byteCount += sizeof(tmp[idx].sensor_id);
+            byteCount = 0;
+            /* Initialize each Sensor Info, idx incremented below */
+            for(idx = 0; idx < asdmHeaderInfo[sdrCount].no_of_records; )
+            {
+                totalSensorInstances = pSdrMetaData[totalRecords].sensorInstance;
+                /* By default totalSensorInstance is considered as 1,
+                * even if its uninitialized
+                */
+                totalSensorInstances = (totalSensorInstances <= 1) ? 1 : totalSensorInstances;
+                /* If Sensor Instance > 1, initialize it in loop */
+                sensorInstance = 0;
+                while(sensorInstance < totalSensorInstances)
+                {
+                    /* Assign  the Sensor Id Count for this RepoType  */
+                    tmp[idx].sensor_id = idx + 1;
+                    byteCount += sizeof(tmp[idx].sensor_id);
 
-		/* Sensor Name
-		 * Based on Name Type and Length allocate Memory for Sensor Name
-		 */
-		if(totalSensorInstances > 1)
-		{
-		    Cl_SecureMemset(snsrName,0x00,SENSOR_NAME_MAX);
-		    pSdrMetaData[totalRecords].getSensorName(sensorInstance,snsrName, &tmp[idx].mspSensorId,&tmp[idx].snsrReadFunc);
-		    snsrNameLen = strlen(snsrName) + 1;
-		}
-		else
-		{
-		    snsrNameLen = strlen(pSdrMetaData[totalRecords].sensorName) + 1;
-		}
-		tmp[idx].sensor_name_type_length = SENSOR_TYPE_ASCII | (snsrNameLen & LENGTH_BITMASK);
-		byteCount += sizeof(tmp[idx].sensor_name_type_length);
+                    /* Sensor Name
+                    * Based on Name Type and Length allocate Memory for Sensor Name
+                    */
+                    if(totalSensorInstances > 1)
+                    {
+                        Cl_SecureMemset(snsrName,0x00,SENSOR_NAME_MAX);
+                        pSdrMetaData[totalRecords].getSensorName(sensorInstance,snsrName, &tmp[idx].mspSensorId,&tmp[idx].snsrReadFunc);
+                        snsrNameLen = strlen(snsrName) + 1;
+                    }
+                    else
+                    {
+                        snsrNameLen = strlen(pSdrMetaData[totalRecords].sensorName) + 1;
+                    }
+                    tmp[idx].sensor_name_type_length = SENSOR_TYPE_ASCII | (snsrNameLen & LENGTH_BITMASK);
+                    byteCount += sizeof(tmp[idx].sensor_name_type_length);
 
-		tmp[idx].sensor_name = (char8 *) pvPortMalloc(snsrNameLen);
-		if(NULL != tmp[idx].sensor_name)
-		{
-			Cl_SecureMemset(tmp[idx].sensor_name, 0x00, snsrNameLen);
-		    if(totalSensorInstances > 1)
-		    {
-		    	Cl_SecureMemcpy(tmp[idx].sensor_name,SENSOR_NAME_MAX,snsrName,snsrNameLen);
-		    }
-		    else
-		    {
-		    	Cl_SecureMemcpy(tmp[idx].sensor_name,SENSOR_NAME_MAX,
-		            pSdrMetaData[totalRecords].sensorName, snsrNameLen);
-		    }
-		}
-		else
-		{
-		    VMC_ERR("Failed to allocate Memory for Sensor Name !!!\n\r");
-		    return -1;
-		}
+                    tmp[idx].sensor_name = (char8 *) pvPortMalloc(snsrNameLen);
+                    if(NULL != tmp[idx].sensor_name)
+                    {
+                        Cl_SecureMemset(tmp[idx].sensor_name, 0x00, snsrNameLen);
+                        if(totalSensorInstances > 1)
+                        {
+                            Cl_SecureMemcpy(tmp[idx].sensor_name,SENSOR_NAME_MAX,snsrName,snsrNameLen);
+                        }
+                        else
+                        {
+                            Cl_SecureMemcpy(tmp[idx].sensor_name,SENSOR_NAME_MAX,
+                                pSdrMetaData[totalRecords].sensorName, snsrNameLen);
+                        }
+                    }
+                    else
+                    {
+                        VMC_ERR("Failed to allocate Memory for Sensor Name !!!\n\r");
+                        return -1;
+                    }
 
-		byteCount += snsrNameLen;
+                    byteCount += snsrNameLen;
 
-		/* Sensor Value */
-		tmp[idx].sensor_value_type_length = pSdrMetaData[totalRecords].snsrValTypeLength;
-		byteCount += sizeof(tmp[idx].sensor_value_type_length);
+                    /* Sensor Value */
+                    tmp[idx].sensor_value_type_length = pSdrMetaData[totalRecords].snsrValTypeLength;
+                    byteCount += sizeof(tmp[idx].sensor_value_type_length);
 
-		snsrValueLen = (pSdrMetaData[totalRecords].snsrValTypeLength & LENGTH_BITMASK);
+                    snsrValueLen = (pSdrMetaData[totalRecords].snsrValTypeLength & LENGTH_BITMASK);
 
 
-		/* Only allocate the Memory, Value will be updated while Monitoring */
-		tmp[idx].sensor_value = (u8 *) pvPortMalloc(snsrValueLen);
-		if(NULL != tmp[idx].sensor_value)
-		{
-			Cl_SecureMemset(tmp[idx].sensor_value, 0x00, snsrValueLen);
-			if(NULL != pSdrMetaData[totalRecords].defaultValue) {
-				/* Value */
-				Cl_SecureMemcpy(tmp[idx].sensor_value,snsrValueLen,pSdrMetaData[totalRecords].defaultValue,snsrValueLen);
-			}
-		}
-		else
-		{
-		    VMC_ERR("Failed to allocate Memory for Sensor Value !!!\n\r");
-		    return -1;
-		}
-		byteCount += snsrValueLen;
+                    /* Only allocate the Memory, Value will be updated while Monitoring */
+                    tmp[idx].sensor_value = (u8 *) pvPortMalloc(snsrValueLen);
+                    if(NULL != tmp[idx].sensor_value)
+                    {
+                        Cl_SecureMemset(tmp[idx].sensor_value, 0x00, snsrValueLen);
+                        if(NULL != pSdrMetaData[totalRecords].defaultValue) {
+                            /* Value */
+                            Cl_SecureMemcpy(tmp[idx].sensor_value,snsrValueLen,pSdrMetaData[totalRecords].defaultValue,snsrValueLen);
+                        }
+                    }
+                    else
+                    {
+                        VMC_ERR("Failed to allocate Memory for Sensor Value !!!\n\r");
+                        return -1;
+                    }
+                    byteCount += snsrValueLen;
 
-		/* Sensor Units */
-		tmp[idx].sensor_base_unit_type_length = sensor_unit_tbl[currentRepoType].sensorUnitTypeLen;
-		byteCount += sizeof(tmp[idx].sensor_base_unit_type_length);
+                    /* Sensor Units */
+                    tmp[idx].sensor_base_unit_type_length = sensor_unit_tbl[currentRepoType].sensorUnitTypeLen;
+                    byteCount += sizeof(tmp[idx].sensor_base_unit_type_length);
 
-		if(tmp[idx].sensor_base_unit_type_length != 0)
-		{
-		    baseUnitLen = (tmp[idx].sensor_base_unit_type_length & LENGTH_BITMASK);
+                    if(tmp[idx].sensor_base_unit_type_length != 0)
+                    {
+                        baseUnitLen = (tmp[idx].sensor_base_unit_type_length & LENGTH_BITMASK);
 
-		    tmp[idx].sensor_base_unit = (u8 *) pvPortMalloc(baseUnitLen);
-		    if(NULL != tmp[idx].sensor_base_unit)
-		    {
-		    	Cl_SecureMemset(tmp[idx].sensor_base_unit, 0x00, baseUnitLen);
-		    	Cl_SecureMemcpy(tmp[idx].sensor_base_unit,baseUnitLen,
-					sensor_unit_tbl[currentRepoType].baseUnit, baseUnitLen);
-		    }
-		    else
-		    {
-			VMC_ERR("Failed to allocate Memory for BaseUnit !!");
-			return -1;
-		    }
-		    byteCount += baseUnitLen;
-		}
+                        tmp[idx].sensor_base_unit = (u8 *) pvPortMalloc(baseUnitLen);
+                        if(NULL != tmp[idx].sensor_base_unit)
+                        {
+                            Cl_SecureMemset(tmp[idx].sensor_base_unit, 0x00, baseUnitLen);
+                            Cl_SecureMemcpy(tmp[idx].sensor_base_unit,baseUnitLen,
+                                sensor_unit_tbl[currentRepoType].baseUnit, baseUnitLen);
+                        }
+                        else
+                        {
+                        VMC_ERR("Failed to allocate Memory for BaseUnit !!");
+                        return -1;
+                        }
+                        byteCount += baseUnitLen;
+                    }
 
-		/* Sensor unit modifier */
-		tmp[idx].sensor_unit_modifier_byte = pSdrMetaData[totalRecords].snsrUnitModifier;
-		byteCount += sizeof(tmp[idx].sensor_unit_modifier_byte) ;
+                    /* Sensor unit modifier */
+                    tmp[idx].sensor_unit_modifier_byte = pSdrMetaData[totalRecords].snsrUnitModifier;
+                    byteCount += sizeof(tmp[idx].sensor_unit_modifier_byte) ;
 
-		/* Sensor Threshold support byte */
-		tmp[idx].threshold_support_byte = pSdrMetaData[totalRecords].supportedThreshold;
-		byteCount += sizeof(tmp[idx].threshold_support_byte);
+                    /* Sensor Threshold support byte */
+                    tmp[idx].threshold_support_byte = pSdrMetaData[totalRecords].supportedThreshold;
+                    byteCount += sizeof(tmp[idx].threshold_support_byte);
 
-		/* Do not bother to check for BOARD INFO Sensor */
-		if(sdrInfo[sdrCount].header.repository_type != BoardInfoSDR)
-		{
-			getThresholdIdx(&threshIdx, tmp[idx].sensor_name, snsrNameLen);
+                    /* Do not bother to check for BOARD INFO Sensor */
+                    if(sdrInfo[sdrCount].header.repository_type != BoardInfoSDR)
+                    {
+                        getThresholdIdx(&threshIdx, tmp[idx].sensor_name, snsrNameLen);
 
-			/* Allocate the Supported Thresholds */
-			if(tmp[idx].threshold_support_byte & Lower_Fatal_Threshold)
-			{
-				tmp[idx].lower_fatal_limit = (u8 *) pvPortMalloc(snsrValueLen);
-				if(NULL == tmp[idx].lower_fatal_limit)
-				{
-					/* LOG Error and return */
-					VMC_ERR("Failed to allocate Memory for lower_fatal_limit !!!\n\r");
-					return -1;
-				}
-				Cl_SecureMemset(tmp[idx].lower_fatal_limit,0x00, snsrValueLen);
-				Cl_SecureMemcpy(tmp[idx].lower_fatal_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].lowerFatalLimit,snsrValueLen);
-				byteCount += snsrValueLen;
-			}
+                        /* Allocate the Supported Thresholds */
+                        if(tmp[idx].threshold_support_byte & Lower_Fatal_Threshold)
+                        {
+                            tmp[idx].lower_fatal_limit = (u8 *) pvPortMalloc(snsrValueLen);
+                            if(NULL == tmp[idx].lower_fatal_limit)
+                            {
+                                /* LOG Error and return */
+                                VMC_ERR("Failed to allocate Memory for lower_fatal_limit !!!\n\r");
+                                return -1;
+                            }
+                            Cl_SecureMemset(tmp[idx].lower_fatal_limit,0x00, snsrValueLen);
+                            Cl_SecureMemcpy(tmp[idx].lower_fatal_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].lowerFatalLimit,snsrValueLen);
+                            byteCount += snsrValueLen;
+                        }
 
-			if(tmp[idx].threshold_support_byte & Lower_Critical_Threshold)
-			{
-				tmp[idx].lower_critical_limit = (u8 *) pvPortMalloc(snsrValueLen);
-				if(NULL == tmp[idx].lower_critical_limit)
-				{
-					/* LOG Error and return */
-					VMC_ERR("Failed to allocate Memory for lower_critical_limit !!!\n\r");
-					return -1;
-				}
-				Cl_SecureMemset(tmp[idx].lower_critical_limit,0x00, snsrValueLen);
-				Cl_SecureMemcpy(tmp[idx].lower_critical_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].lowerCritLimit,snsrValueLen);
-				byteCount += snsrValueLen;
-			}
+                        if(tmp[idx].threshold_support_byte & Lower_Critical_Threshold)
+                        {
+                            tmp[idx].lower_critical_limit = (u8 *) pvPortMalloc(snsrValueLen);
+                            if(NULL == tmp[idx].lower_critical_limit)
+                            {
+                                /* LOG Error and return */
+                                VMC_ERR("Failed to allocate Memory for lower_critical_limit !!!\n\r");
+                                return -1;
+                            }
+                            Cl_SecureMemset(tmp[idx].lower_critical_limit,0x00, snsrValueLen);
+                            Cl_SecureMemcpy(tmp[idx].lower_critical_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].lowerCritLimit,snsrValueLen);
+                            byteCount += snsrValueLen;
+                        }
 
-			if(tmp[idx].threshold_support_byte & Lower_Warning_Threshold)
-			{
-				tmp[idx].lower_warning_limit = (u8 *) pvPortMalloc(snsrValueLen);
-				if(NULL == tmp[idx].lower_warning_limit)
-				{
-					/* LOG Error and return */
-					VMC_ERR("Failed to allocate Memory for lower_warning_limit !!!\n\r");
-					return -1;
-				}
-				Cl_SecureMemset(tmp[idx].lower_warning_limit,0x00, snsrValueLen);
-				Cl_SecureMemcpy(tmp[idx].lower_warning_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].lowerWarnLimit,snsrValueLen);
-				byteCount += snsrValueLen;
-			}
+                        if(tmp[idx].threshold_support_byte & Lower_Warning_Threshold)
+                        {
+                            tmp[idx].lower_warning_limit = (u8 *) pvPortMalloc(snsrValueLen);
+                            if(NULL == tmp[idx].lower_warning_limit)
+                            {
+                                /* LOG Error and return */
+                                VMC_ERR("Failed to allocate Memory for lower_warning_limit !!!\n\r");
+                                return -1;
+                            }
+                            Cl_SecureMemset(tmp[idx].lower_warning_limit,0x00, snsrValueLen);
+                            Cl_SecureMemcpy(tmp[idx].lower_warning_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].lowerWarnLimit,snsrValueLen);
+                            byteCount += snsrValueLen;
+                        }
 
-			if(tmp[idx].threshold_support_byte & Upper_Fatal_Threshold)
-			{
-				tmp[idx].upper_fatal_limit = (u8 *) pvPortMalloc(snsrValueLen);
-				if(NULL == tmp[idx].upper_fatal_limit)
-				{
-					/* LOG Error and return */
-					VMC_ERR("Failed to allocate Memory for upper_fatal_limit !!!\n\r");
-					return -1;
-				}
-				Cl_SecureMemset(tmp[idx].upper_fatal_limit,0x00, snsrValueLen);
-				Cl_SecureMemcpy(tmp[idx].upper_fatal_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].upperFatalLimit, snsrValueLen);
-				byteCount += snsrValueLen;
-			}
+                        if(tmp[idx].threshold_support_byte & Upper_Fatal_Threshold)
+                        {
+                            tmp[idx].upper_fatal_limit = (u8 *) pvPortMalloc(snsrValueLen);
+                            if(NULL == tmp[idx].upper_fatal_limit)
+                            {
+                                /* LOG Error and return */
+                                VMC_ERR("Failed to allocate Memory for upper_fatal_limit !!!\n\r");
+                                return -1;
+                            }
+                            Cl_SecureMemset(tmp[idx].upper_fatal_limit,0x00, snsrValueLen);
+                            Cl_SecureMemcpy(tmp[idx].upper_fatal_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].upperFatalLimit, snsrValueLen);
+                            byteCount += snsrValueLen;
+                        }
 
-			if(tmp[idx].threshold_support_byte & Upper_Critical_Threshold)
-			{
-				tmp[idx].upper_critical_limit = (u8 *) pvPortMalloc(snsrValueLen);
-				if(NULL == tmp[idx].upper_critical_limit)
-				{
-					/* LOG Error and return */
-					VMC_ERR("Failed to allocate Memory for upper_critical_limit !!!\n\r");
-					return -1;
-				}
-				Cl_SecureMemset(tmp[idx].upper_critical_limit,0x00, snsrValueLen);
-				Cl_SecureMemcpy(tmp[idx].upper_critical_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].upperCritLimit, snsrValueLen);
-				byteCount += snsrValueLen;
-			}
+                        if(tmp[idx].threshold_support_byte & Upper_Critical_Threshold)
+                        {
+                            tmp[idx].upper_critical_limit = (u8 *) pvPortMalloc(snsrValueLen);
+                            if(NULL == tmp[idx].upper_critical_limit)
+                            {
+                                /* LOG Error and return */
+                                VMC_ERR("Failed to allocate Memory for upper_critical_limit !!!\n\r");
+                                return -1;
+                            }
+                            Cl_SecureMemset(tmp[idx].upper_critical_limit,0x00, snsrValueLen);
+                            Cl_SecureMemcpy(tmp[idx].upper_critical_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].upperCritLimit, snsrValueLen);
+                            byteCount += snsrValueLen;
+                        }
 
-			if(tmp[idx].threshold_support_byte & Upper_Warning_Threshold)
-			{
-				tmp[idx].upper_warning_limit = (u8 *) pvPortMalloc(snsrValueLen);
-				if(NULL == tmp[idx].upper_warning_limit)
-				{
-					/* LOG Error and return */
-					VMC_ERR("Failed to allocate Memory for upper_warning_limit !!!\n\r");
-					return -1;
-				}
-				Cl_SecureMemset(tmp[idx].upper_warning_limit,0x00, snsrValueLen);
-				Cl_SecureMemcpy(tmp[idx].upper_warning_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].upperWarnLimit, snsrValueLen);
-				byteCount += snsrValueLen;
-			}
-		}
+                        if(tmp[idx].threshold_support_byte & Upper_Warning_Threshold)
+                        {
+                            tmp[idx].upper_warning_limit = (u8 *) pvPortMalloc(snsrValueLen);
+                            if(NULL == tmp[idx].upper_warning_limit)
+                            {
+                                /* LOG Error and return */
+                                VMC_ERR("Failed to allocate Memory for upper_warning_limit !!!\n\r");
+                                return -1;
+                            }
+                            Cl_SecureMemset(tmp[idx].upper_warning_limit,0x00, snsrValueLen);
+                            Cl_SecureMemcpy(tmp[idx].upper_warning_limit,snsrValueLen,&thresholds_limit_tbl[threshIdx].upperWarnLimit, snsrValueLen);
+                            byteCount += snsrValueLen;
+                        }
+                    }
 
-		/* Sensor Status */
-		tmp[idx].sensor_status = Sensor_Present_And_Valid;
-		byteCount += sizeof(tmp[idx].sensor_status);
+                    /* Sensor Status */
+                    tmp[idx].sensor_status = Sensor_Present_And_Valid;
+                    byteCount += sizeof(tmp[idx].sensor_status);
 
-		/* Update the Sample count, byteCount update not required (internal element) */
-		tmp[idx].sampleCount = pSdrMetaData[totalRecords].sampleCount;
+                    /* Update the Sample count, byteCount update not required (internal element) */
+                    tmp[idx].sampleCount = pSdrMetaData[totalRecords].sampleCount;
 
-		/* Sample Count > 0, for only for Dynamic sensors */
-		if( pSdrMetaData[totalRecords].sampleCount > 0)
-		{
-		    tmp[idx].sensorMaxValue = (u8 *) pvPortMalloc(snsrValueLen);
-		    if(NULL == tmp[idx].sensorMaxValue)
-		    {
-			/* LOG Error and return */
-			VMC_ERR("Failed to allocate Memory for sensorMaxValue !!!\n\r");
-			return -1;
-		    }
-		    Cl_SecureMemset(tmp[idx].sensorMaxValue,0x00, snsrValueLen);
-		    byteCount += snsrValueLen;
+                    /* Sample Count > 0, for only for Dynamic sensors */
+                    if( pSdrMetaData[totalRecords].sampleCount > 0)
+                    {
+                        tmp[idx].sensorMaxValue = (u8 *) pvPortMalloc(snsrValueLen);
+                        if(NULL == tmp[idx].sensorMaxValue)
+                        {
+                            /* LOG Error and return */
+                            VMC_ERR("Failed to allocate Memory for sensorMaxValue !!!\n\r");
+                            return -1;
+                        }
+                        Cl_SecureMemset(tmp[idx].sensorMaxValue,0x00, snsrValueLen);
+                        byteCount += snsrValueLen;
 
-		    tmp[idx].sensorAverageValue = (u8 *) pvPortMalloc(snsrValueLen);
-		    if(NULL == tmp[idx].sensorAverageValue)
-		    {
-			/* LOG Error and return */
-			VMC_ERR("Failed to allocate Memory for sensorAverageValue !!!\n\r");
-			return -1;
-		    }
-		    Cl_SecureMemset(tmp[idx].sensorAverageValue,0x00, snsrValueLen);
-		    byteCount += snsrValueLen;
-		}
+                        tmp[idx].sensorAverageValue = (u8 *) pvPortMalloc(snsrValueLen);
+                        if(NULL == tmp[idx].sensorAverageValue)
+                        {
+                            /* LOG Error and return */
+                            VMC_ERR("Failed to allocate Memory for sensorAverageValue !!!\n\r");
+                            return -1;
+                        }
+                        Cl_SecureMemset(tmp[idx].sensorAverageValue,0x00, snsrValueLen);
+                        byteCount += snsrValueLen;
+                    }
 
-		tmp[idx].sensorInstance = sensorInstance;
-		/* Assign the Sensor ID Mapped to external  MSP (Internal)*/
-		if(totalSensorInstances > 1)
-		{
-		    /* Gets updated during Sensor Name initialization */
-		}
-		else
-		{
-		    tmp[idx].mspSensorId = pSdrMetaData[totalRecords].sensorListTbl;
-		    tmp[idx].snsrReadFunc = pSdrMetaData[totalRecords].monitorFunc;
-		}
+                    tmp[idx].sensorInstance = sensorInstance;
+                    /* Assign the Sensor ID Mapped to external  MSP (Internal)*/
+                    if(totalSensorInstances > 1)
+                    {
+                        /* Gets updated during Sensor Name initialization */
+                    }
+                    else
+                    {
+                        tmp[idx].mspSensorId = pSdrMetaData[totalRecords].sensorListTbl;
+                        tmp[idx].snsrReadFunc = pSdrMetaData[totalRecords].monitorFunc;
+                    }
 
-		/* Update the Monitor Function for the Sensor (Internal)*/
-		//tmp[idx].snsrReadFunc = pSdrMetaData[totalRecords].monitorFunc;
+                    /* Update the Monitor Function for the Sensor (Internal)*/
+                    //tmp[idx].snsrReadFunc = pSdrMetaData[totalRecords].monitorFunc;
 
-		idx++;
-		sensorInstance++;
-		}
-		/* One Record is initialized, move to the Next SDRMetaData */
-		totalRecords++;
+                    idx++;
+                    sensorInstance++;
+                }
+            /* One Record is initialized, move to the Next SDRMetaData */
+            totalRecords++;
+        }
 
-	    }
+        /* Fill the EOR */
+        Cl_SecureMemcpy(sdrInfo[sdrCount].asdmEOR,ASDM_EOR_MAX_SIZE,"END",sizeof(u8) * strlen("END"));
+        byteCount += (sizeof(u8) * strlen("END"));
 
-	    /* Fill the EOR */
-	    Cl_SecureMemcpy(sdrInfo[sdrCount].asdmEOR,ASDM_EOR_MAX_SIZE,"END",sizeof(u8) * strlen("END"));
-	    byteCount += (sizeof(u8) * strlen("END"));
+        /* Update the Byte Count for this record in Multiple of 8
+         * if not an exact multiple, add pad bytes to round it off */
+        if((byteCount % 8) != 0)
+        {
+            u8 tmp = (byteCount % 8);
+            byteCount += (8 - tmp);
+        }
+        sdrInfo[sdrCount].header.no_of_bytes = (byteCount/8);
+    }
 
-	    /* Update the Byte Count for this record in Multiple of 8
-	     * if not an exact multiple, add pad bytes to round it off */
-	    if((byteCount % 8) != 0)
-	    {
-	    	u8 tmp = (byteCount % 8);
-	    	byteCount += (8 - tmp);
-	    }
-	    sdrInfo[sdrCount].header.no_of_bytes = (byteCount/8);
-	}
-
-	vPortFree(pSdrMetaData);
+        vPortFree(pSdrMetaData);
     }
     else
     {
-	/* Log Error ASDM Init Failed */
-	VMC_LOG("ASDM Init Failed, MetaData not available !!!\n\r");
-	return -1;
+        /* Log Error ASDM Init Failed */
+        VMC_LOG("ASDM Init Failed, MetaData not available !!!\n\r");
+        return -1;
     }
 
     asdmInitSuccess = true;
@@ -838,15 +833,15 @@ s8 Asdm_Get_SDR_Size(u8 *req, u8 *resp, u16 *respSize)
 
     if((req == NULL) || (resp == NULL) || (respSize == NULL))
     {
-	VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r", \
-		req, resp,respSize);
-	return -1;
+        VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r", \
+            req, resp,respSize);
+        return -1;
     }
 
     if(asdmInitSuccess != true)
     {
-	VMC_ERR(" ASDM Data not Initialized yet or has Failed \n\r");
-	return -1;
+        VMC_ERR(" ASDM Data not Initialized yet or has Failed \n\r");
+        return -1;
     }
 
     /* Get the SDR index from the request */
@@ -884,122 +879,122 @@ s8 Asdm_Get_Sensor_Repository(u8 *req, u8 *resp, u16 *respSize)
 
     if((req == NULL) || (resp == NULL) || (respSize == NULL))
     {
-	VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r",
-		req, resp,respIndex);
-	return -1;
+        VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r",
+            req, resp,respIndex);
+        return -1;
     }
 
     sdrIndex = getSDRIndex(req[1]);
 
     if (xSemaphoreTake(sdr_lock, portMAX_DELAY))
     {
-	/* Start from Offset 1 , 0 is for completion code, we fill it at the End */
-	respIndex = 1;
-	/* Populate the Header */
-	Cl_SecureMemcpy(&resp[respIndex], sizeof(Asdm_Header_t), &sdrInfo[sdrIndex].header, sizeof(Asdm_Header_t));
-	respIndex += sizeof(Asdm_Header_t);
+        /* Start from Offset 1 , 0 is for completion code, we fill it at the End */
+        respIndex = 1;
+        /* Populate the Header */
+        Cl_SecureMemcpy(&resp[respIndex], sizeof(Asdm_Header_t), &sdrInfo[sdrIndex].header, sizeof(Asdm_Header_t));
+        respIndex += sizeof(Asdm_Header_t);
 
-	Asdm_SensorRecord_t *tmp = sdrInfo[sdrIndex].sensorRecord;
-	/* Populate the Sensor Records */
-	for(idx = 0; idx < sdrInfo[sdrIndex].header.no_of_records; idx++)
-	{
-	    resp[respIndex++] = tmp[idx].sensor_id;
-	    resp[respIndex++] = tmp[idx].sensor_name_type_length;
+        Asdm_SensorRecord_t *tmp = sdrInfo[sdrIndex].sensorRecord;
+        /* Populate the Sensor Records */
+        for(idx = 0; idx < sdrInfo[sdrIndex].header.no_of_records; idx++)
+        {
+            resp[respIndex++] = tmp[idx].sensor_id;
+            resp[respIndex++] = tmp[idx].sensor_name_type_length;
 
-	    /* Copy Sensor Name */
-	    snsrNameLen = (tmp[idx].sensor_name_type_length & LENGTH_BITMASK);
-	    Cl_SecureMemcpy(&resp[respIndex],snsrNameLen, tmp[idx].sensor_name, snsrNameLen);
-	    respIndex += snsrNameLen;
+            /* Copy Sensor Name */
+            snsrNameLen = (tmp[idx].sensor_name_type_length & LENGTH_BITMASK);
+            Cl_SecureMemcpy(&resp[respIndex],snsrNameLen, tmp[idx].sensor_name, snsrNameLen);
+            respIndex += snsrNameLen;
 
-	    /*  Sensor Value */
-	    resp[respIndex++] = tmp[idx].sensor_value_type_length;
+            /*  Sensor Value */
+            resp[respIndex++] = tmp[idx].sensor_value_type_length;
 
-	    snsrValueLen = (tmp[idx].sensor_value_type_length & LENGTH_BITMASK);
-	    if(snsrValueLen != 0)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex],snsrValueLen, tmp[idx].sensor_value, snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
+            snsrValueLen = (tmp[idx].sensor_value_type_length & LENGTH_BITMASK);
+            if(snsrValueLen != 0)
+            {
+                Cl_SecureMemcpy(&resp[respIndex],snsrValueLen, tmp[idx].sensor_value, snsrValueLen);
+                respIndex += snsrValueLen;
+            }
 
-	    /* Sensor Base unit */
-	    resp[respIndex++] = tmp[idx].sensor_base_unit_type_length;
+            /* Sensor Base unit */
+            resp[respIndex++] = tmp[idx].sensor_base_unit_type_length;
 
-	    baseUnitLen = (tmp[idx].sensor_base_unit_type_length & LENGTH_BITMASK);
-	    if(baseUnitLen != 0)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex],baseUnitLen, tmp[idx].sensor_base_unit, baseUnitLen);
-		respIndex += baseUnitLen;
-	    }
+            baseUnitLen = (tmp[idx].sensor_base_unit_type_length & LENGTH_BITMASK);
+            if(baseUnitLen != 0)
+            {
+                Cl_SecureMemcpy(&resp[respIndex],baseUnitLen, tmp[idx].sensor_base_unit, baseUnitLen);
+                respIndex += baseUnitLen;
+            }
 
-	    resp[respIndex++] = tmp[idx].sensor_unit_modifier_byte;
+            resp[respIndex++] = tmp[idx].sensor_unit_modifier_byte;
 
-	    /* Sensor Thresholds */
-	    resp[respIndex++] = tmp[idx].threshold_support_byte;
+            /* Sensor Thresholds */
+            resp[respIndex++] = tmp[idx].threshold_support_byte;
 
-	    if(tmp[idx].threshold_support_byte & Lower_Fatal_Threshold)
-	    {
-	    Cl_SecureMemcpy(&resp[respIndex],snsrValueLen, tmp[idx].lower_fatal_limit,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
-	    if(tmp[idx].threshold_support_byte & Lower_Critical_Threshold)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].lower_critical_limit,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
-	    if(tmp[idx].threshold_support_byte & Lower_Warning_Threshold)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].lower_warning_limit,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
-	    if(tmp[idx].threshold_support_byte & Upper_Fatal_Threshold)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[idx].upper_fatal_limit,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
-	    if(tmp[idx].threshold_support_byte & Upper_Critical_Threshold)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].upper_critical_limit,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
-	    if(tmp[idx].threshold_support_byte & Upper_Warning_Threshold)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].upper_warning_limit,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
+            if(tmp[idx].threshold_support_byte & Lower_Fatal_Threshold)
+            {
+                Cl_SecureMemcpy(&resp[respIndex],snsrValueLen, tmp[idx].lower_fatal_limit,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
+            if(tmp[idx].threshold_support_byte & Lower_Critical_Threshold)
+            {
+                Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].lower_critical_limit,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
+            if(tmp[idx].threshold_support_byte & Lower_Warning_Threshold)
+            {
+                Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].lower_warning_limit,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
+            if(tmp[idx].threshold_support_byte & Upper_Fatal_Threshold)
+            {
+                Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[idx].upper_fatal_limit,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
+            if(tmp[idx].threshold_support_byte & Upper_Critical_Threshold)
+            {
+                Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].upper_critical_limit,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
+            if(tmp[idx].threshold_support_byte & Upper_Warning_Threshold)
+            {
+                Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].upper_warning_limit,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
 
-	    resp[respIndex++] =  tmp[idx].sensor_status;
+            resp[respIndex++] =  tmp[idx].sensor_status;
 
-	    if(tmp[idx].threshold_support_byte & Sensor_Avg_Val_Support)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].sensorAverageValue,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
+            if(tmp[idx].threshold_support_byte & Sensor_Avg_Val_Support)
+            {
+                Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].sensorAverageValue,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
 
-	    if(tmp[idx].threshold_support_byte & Sensor_Max_Val_Support)
-	    {
-		Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].sensorMaxValue,snsrValueLen);
-		respIndex += snsrValueLen;
-	    }
-	}
+            if(tmp[idx].threshold_support_byte & Sensor_Max_Val_Support)
+            {
+                Cl_SecureMemcpy(&resp[respIndex], snsrValueLen,tmp[idx].sensorMaxValue,snsrValueLen);
+                respIndex += snsrValueLen;
+            }
+        }
 
-	/* Populate the EOR "END" */
-	Cl_SecureMemcpy(&resp[respIndex],ASDM_EOR_MAX_SIZE, sdrInfo[sdrIndex].asdmEOR, (sizeof(u8) * strlen("END")));
-	respIndex += (sizeof(u8) * strlen("END"));
+        /* Populate the EOR "END" */
+        Cl_SecureMemcpy(&resp[respIndex],ASDM_EOR_MAX_SIZE, sdrInfo[sdrIndex].asdmEOR, (sizeof(u8) * strlen("END")));
+        respIndex += (sizeof(u8) * strlen("END"));
 
-	/* Release the Lock */
-	xSemaphoreGive(sdr_lock);
+        /* Release the Lock */
+        xSemaphoreGive(sdr_lock);
 
-	resp[0] = Asdm_CC_Operation_Success;
-	*respSize = respIndex;
+        resp[0] = Asdm_CC_Operation_Success;
+        *respSize = respIndex;
 
-	retStatus = 0;
+        retStatus = 0;
     }
     else
     {
-	retStatus = -1;
-	VMC_ERR("Unable to Acquire Sdr Lock \n\r");
-	resp[0] = Asdm_CC_Operation_Failed;
-	*respSize = 1;
+        retStatus = -1;
+        VMC_ERR("Unable to Acquire Sdr Lock \n\r");
+        resp[0] = Asdm_CC_Operation_Failed;
+        *respSize = 1;
     }
 
 
@@ -1008,76 +1003,76 @@ s8 Asdm_Get_Sensor_Repository(u8 *req, u8 *resp, u16 *respSize)
 
 s8 Asdm_Get_All_Sensor_Data(u8 *req, u8 *resp, u16 *respSize)
 {
-	u8 sdrIndex = 0;
-	u8 snsrIndex = 0;
-	u8 total_records = 0;
-	u8 payload_size = 0;
-	u8 snsrValueLen = 0;
-	u8 snsrStatusLen = 0;
+    u8 sdrIndex = 0;
+    u8 snsrIndex = 0;
+    u8 total_records = 0;
+    u8 payload_size = 0;
+    u8 snsrValueLen = 0;
+    u8 snsrStatusLen = 0;
 
-	u16 respIndex = 0;
+    u16 respIndex = 0;
 
-	if((req == NULL) || (resp == NULL) || (respSize == NULL)) {
-		VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r",
-				req, resp,respSize);
-		return -1;
-	}
+    if((req == NULL) || (resp == NULL) || (respSize == NULL)) {
+        VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r",
+                req, resp,respSize);
+        return -1;
+    }
 
-	if(asdmInitSuccess != true) {
-		VMC_ERR(" ASDM Data not Initialized yet or has Failed \n\r");
-		return -1;
-	}
+    if(asdmInitSuccess != true) {
+        VMC_ERR(" ASDM Data not Initialized yet or has Failed \n\r");
+        return -1;
+    }
 
-	sdrIndex = getSDRIndex(req[ASDM_REQ_BYTE_REPO_TYPE]);
-	total_records = sdrInfo[sdrIndex].header.no_of_records;
+    sdrIndex = getSDRIndex(req[ASDM_REQ_BYTE_REPO_TYPE]);
+    total_records = sdrInfo[sdrIndex].header.no_of_records;
 
-	*respSize = 0;
-	payload_size = 0;
+    *respSize = 0;
+    payload_size = 0;
 
-	if (xSemaphoreTake(sdr_lock, portMAX_DELAY)) {
-		/* Fetch the Sensor Record to extract the Value */
-		Asdm_SensorRecord_t *tmp = sdrInfo[sdrIndex].sensorRecord;
+    if (xSemaphoreTake(sdr_lock, portMAX_DELAY)) {
+        /* Fetch the Sensor Record to extract the Value */
+        Asdm_SensorRecord_t *tmp = sdrInfo[sdrIndex].sensorRecord;
 
-		resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Success;
+        resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Success;
 
-		/* Copy the Repo Type */
-		resp[ASDM_RESP_BYTE_REPO_TYPE] = req[ASDM_REQ_BYTE_REPO_TYPE];
+        /* Copy the Repo Type */
+        resp[ASDM_RESP_BYTE_REPO_TYPE] = req[ASDM_REQ_BYTE_REPO_TYPE];
 
-		/* Send the Index to copy the Payload */
-		respIndex = ASDM_RESP_BYTE_SNSR_SIZE + 1;
+        /* Send the Index to copy the Payload */
+        respIndex = ASDM_RESP_BYTE_SNSR_SIZE + 1;
 
-		/* Sensor Id are 1 indexed, but we have 0 indexed */
-		for(snsrIndex = 0; snsrIndex < total_records; snsrIndex++) {
+        /* Sensor Id are 1 indexed, but we have 0 indexed */
+        for(snsrIndex = 0; snsrIndex < total_records; snsrIndex++) {
 
-			/* Size of sensor Value * 3( Snsr Val + Max Snsr Val + Snsr Avg) */
-			snsrValueLen = (tmp[snsrIndex].sensor_value_type_length & LENGTH_BITMASK);
-			snsrStatusLen = sizeof(tmp[snsrIndex].sensor_status);
+            /* Size of sensor Value * 3( Snsr Val + Max Snsr Val + Snsr Avg) */
+            snsrValueLen = (tmp[snsrIndex].sensor_value_type_length & LENGTH_BITMASK);
+            snsrStatusLen = sizeof(tmp[snsrIndex].sensor_status);
 
-			payload_size += ( sizeof(snsrValueLen) + (3 * snsrValueLen) + snsrStatusLen);
+            payload_size += ( sizeof(snsrValueLen) + (3 * snsrValueLen) + snsrStatusLen);
 
-			resp[respIndex++] = snsrValueLen;
+            resp[respIndex++] = snsrValueLen;
 
-			Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensor_value,snsrValueLen);
-			respIndex += snsrValueLen;
-			Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorMaxValue,snsrValueLen);
-			respIndex += snsrValueLen;
-			Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorAverageValue,snsrValueLen);
-			respIndex += snsrValueLen;
-			Cl_SecureMemcpy(&resp[respIndex],snsrStatusLen,&tmp[snsrIndex].sensor_status,snsrStatusLen);
-			respIndex += snsrStatusLen;
-		}
-		xSemaphoreGive(sdr_lock);
+            Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensor_value,snsrValueLen);
+            respIndex += snsrValueLen;
+            Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorMaxValue,snsrValueLen);
+            respIndex += snsrValueLen;
+            Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorAverageValue,snsrValueLen);
+            respIndex += snsrValueLen;
+            Cl_SecureMemcpy(&resp[respIndex],snsrStatusLen,&tmp[snsrIndex].sensor_status,snsrStatusLen);
+            respIndex += snsrStatusLen;
+        }
+        xSemaphoreGive(sdr_lock);
 
-		resp[ASDM_RESP_BYTE_SNSR_SIZE] = payload_size;
-		/* 3 -> Length of (CC + REPOTYPE + Payload_Size) */
-		*respSize = 3 + payload_size;
+        resp[ASDM_RESP_BYTE_SNSR_SIZE] = payload_size;
+        /* 3 -> Length of (CC + REPOTYPE + Payload_Size) */
+        *respSize = 3 + payload_size;
 
-	} else {
-		resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Failed;
-		*respSize = 1;
-	}
+    } else {
+        resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Failed;
+        *respSize = 1;
+    }
 
-	return 0;
+    return 0;
 }
 
 s8 Asdm_Get_Sensor_Data(u8 *req, u8 *resp, u16 *respSize)
@@ -1091,15 +1086,15 @@ s8 Asdm_Get_Sensor_Data(u8 *req, u8 *resp, u16 *respSize)
 
     if((req == NULL) || (resp == NULL) || (respSize == NULL))
     {
-	VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r",
-		req, resp,respSize);
-	return -1;
+        VMC_ERR(" Buffers received are NULL.\n\r req : %p, resp : %p, respSize : %p \n\r",
+            req, resp,respSize);
+        return -1;
     }
 
     if(asdmInitSuccess != true)
     {
-	VMC_ERR(" ASDM Data not Initialized yet or has Failed \n\r");
-	return -1;
+        VMC_ERR(" ASDM Data not Initialized yet or has Failed \n\r");
+        return -1;
     }
 
     sdrIndex = getSDRIndex(req[ASDM_REQ_BYTE_REPO_TYPE]);
@@ -1109,38 +1104,38 @@ s8 Asdm_Get_Sensor_Data(u8 *req, u8 *resp, u16 *respSize)
 
     if (xSemaphoreTake(sdr_lock, portMAX_DELAY))
     {
-    	/* Fetch the Sensor Record to extract the Value */
-    	Asdm_SensorRecord_t *tmp = sdrInfo[sdrIndex].sensorRecord;
+        /* Fetch the Sensor Record to extract the Value */
+        Asdm_SensorRecord_t *tmp = sdrInfo[sdrIndex].sensorRecord;
 
-    	resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Success;
-    	respIndex = ASDM_RESP_BYTE_CC + 1;
+        resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Success;
+        respIndex = ASDM_RESP_BYTE_CC + 1;
 
-    	/* Copy the Repo Type */
-    	resp[ASDM_RESP_BYTE_REPO_TYPE] = req[ASDM_REQ_BYTE_REPO_TYPE];
-    	respIndex = ASDM_RESP_BYTE_REPO_TYPE + 1;
+        /* Copy the Repo Type */
+        resp[ASDM_RESP_BYTE_REPO_TYPE] = req[ASDM_REQ_BYTE_REPO_TYPE];
+        respIndex = ASDM_RESP_BYTE_REPO_TYPE + 1;
 
-    	/* Size of sensor Value * 3( Snsr Val + Max Snsr Val + Snsr Avg) */
-    	snsrValueLen = (tmp[snsrIndex].sensor_value_type_length & LENGTH_BITMASK);
-    	snsrStatusLen = sizeof(tmp[snsrIndex].sensor_status);
+        /* Size of sensor Value * 3( Snsr Val + Max Snsr Val + Snsr Avg) */
+        snsrValueLen = (tmp[snsrIndex].sensor_value_type_length & LENGTH_BITMASK);
+        snsrStatusLen = sizeof(tmp[snsrIndex].sensor_status);
 
-    	resp[respIndex++] = snsrValueLen;
+        resp[respIndex++] = snsrValueLen;
 
-    	Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensor_value,snsrValueLen);
-    	respIndex += snsrValueLen;
-    	Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorMaxValue,snsrValueLen);
-    	respIndex += snsrValueLen;
-    	Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorAverageValue,snsrValueLen);
-    	respIndex += snsrValueLen;
-    	Cl_SecureMemcpy(&resp[respIndex],snsrStatusLen,&tmp[snsrIndex].sensor_status,snsrStatusLen);
-    	respIndex += snsrStatusLen;
+        Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensor_value,snsrValueLen);
+        respIndex += snsrValueLen;
+        Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorMaxValue,snsrValueLen);
+        respIndex += snsrValueLen;
+        Cl_SecureMemcpy(&resp[respIndex],snsrValueLen,tmp[snsrIndex].sensorAverageValue,snsrValueLen);
+        respIndex += snsrValueLen;
+        Cl_SecureMemcpy(&resp[respIndex],snsrStatusLen,&tmp[snsrIndex].sensor_status,snsrStatusLen);
+        respIndex += snsrStatusLen;
 
-    	xSemaphoreGive(sdr_lock);
-    	*respSize = respIndex;
+        xSemaphoreGive(sdr_lock);
+        *respSize = respIndex;
     }
     else
     {
-	resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Failed;
-	*respSize = 1;
+        resp[ASDM_RESP_BYTE_CC] = Asdm_CC_Operation_Failed;
+        *respSize = 1;
     }
 
     return 0;
@@ -1204,40 +1199,48 @@ void Asdm_Update_Sensors(void)
         /* Update the MSP FW version */
         Asdm_Update_Active_MSP_sensor();
 
-		for(sdrIndex = 0; sdrIndex < MAX_SDR_REPO ; sdrIndex++)
-		{
-			Asdm_SensorRecord_t *sensorRecord = sdrInfo[sdrIndex].sensorRecord;
+        if (xSemaphoreTake(sdr_lock, portMAX_DELAY))
+        {
+            for(sdrIndex = 0; sdrIndex < MAX_SDR_REPO ; sdrIndex++)
+            {
+                Asdm_SensorRecord_t *sensorRecord = sdrInfo[sdrIndex].sensorRecord;
 
-			if(NULL != sensorRecord)
-			{
-				for(idx = 0; idx < sdrInfo[sdrIndex].header.no_of_records; idx++)
-				{
-					/* Check if a Monitor Function is registered for this sensor */
-					if(NULL != sensorRecord[idx].snsrReadFunc)
-					{
-						Cl_SecureMemset(&snsrData, 0x00, sizeof(snsrRead_t));
+                if(NULL != sensorRecord)
+                {
+                    for(idx = 0; idx < sdrInfo[sdrIndex].header.no_of_records; idx++)
+                    {
+                        /* Check if a Monitor Function is registered for this sensor */
+                        if(NULL != sensorRecord[idx].snsrReadFunc)
+                        {
+                            Cl_SecureMemset(&snsrData, 0x00, sizeof(snsrRead_t));
 
-						snsrData.sensorInstance = sensorRecord[idx].sensorInstance;
-						snsrData.mspSensorIndex = sensorRecord[idx].mspSensorId;
+                            snsrData.sensorInstance = sensorRecord[idx].sensorInstance;
+                            snsrData.mspSensorIndex = sensorRecord[idx].mspSensorId;
 
-						sensorRecord[idx].snsrReadFunc(&snsrData);
+                            sensorRecord[idx].snsrReadFunc(&snsrData);
 
-							/* Update the Sensor Data in SDR records */
-						Update_Sensor_Value(sdrInfo[sdrIndex].header.repository_type,
-								sensorRecord[idx].sensor_id, &snsrData);
+                            /* Update the Sensor Data in SDR records */
+                            Update_Sensor_Value(sdrInfo[sdrIndex].header.repository_type,sensorRecord[idx].sensor_id, &snsrData);
 
-					}
-				}
-			}
-			else
-			{
-				VMC_ERR("Invalid SDR Data \n\r");
-			}
-		}
+                        }
+                    }
+                }
+                else
+                {
+                    VMC_ERR("Invalid SDR Data \n\r");
+                }
+            }
+
+            xSemaphoreGive(sdr_lock);
+        }
+        else
+        {
+            VMC_ERR("Failed to Acquire sdr lock\n\r");
+        }
     }
     else
     {
-    	VMC_ERR("ASDM not yet Initialized \n\r");
+        VMC_ERR("ASDM not yet Initialized \n\r");
     }
 }
 
@@ -1259,58 +1262,58 @@ void AsdmSensor_Display(void)
     VMC_PRNT("|   Sensor Name    |   Value     | Status |    Max    |   Average | \n\r");
     for(sdrIndex = 0; sdrIndex < MAX_SDR_REPO ; sdrIndex++)
     {
-	Asdm_SensorRecord_t *sensorRecord = sdrInfo[sdrIndex].sensorRecord;
+        Asdm_SensorRecord_t *sensorRecord = sdrInfo[sdrIndex].sensorRecord;
 
-	VMC_PRNT("\n\rRecord Type : 0x%x \n\r",sdrInfo[sdrIndex].header.repository_type);
-	VMC_PRNT("----------------------------------------------------------------\n\r");
-	if(NULL != sensorRecord)
-	{
-	    for(idx = 0; idx < sdrInfo[sdrIndex].header.no_of_records; idx++)
-	    {
-		if(sensorRecord[idx].sampleCount < 1)
-		{
-			if(sensorRecord[idx].sensor_value_type_length & SENSOR_TYPE_ASCII)
-			{
-				VMC_PRNT(" %s		%s	%s	NA	NA \n\r",(sensorRecord[idx].sensor_name),
-					(sensorRecord[idx].sensor_value),
-					((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal)
-					 ? "Ok":"Error"));
-			}
-			else
-			{
-				u8 stringLen = (sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK);
-				VMC_PRNT(" %s		",(sensorRecord[idx].sensor_name),
-					((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal)
-					? "Ok":"Error"));
-				for(stringCount = 0; stringCount< stringLen ; stringCount++)
-				{
-					VMC_PRNT("%x",sensorRecord[idx].sensor_value[stringCount]);
-				}
-				VMC_PRNT("	%s	NA	NA \n\r",					((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal)
-					? "Ok":"Error"));
-			}
-		}
-		else if((sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK) < 4)
-		{
+        VMC_PRNT("\n\rRecord Type : 0x%x \n\r",sdrInfo[sdrIndex].header.repository_type);
+        VMC_PRNT("----------------------------------------------------------------\n\r");
+        if(NULL != sensorRecord)
+        {
+            for(idx = 0; idx < sdrInfo[sdrIndex].header.no_of_records; idx++)
+            {
+                if(sensorRecord[idx].sampleCount < 1)
+                {
+                    if(sensorRecord[idx].sensor_value_type_length & SENSOR_TYPE_ASCII)
+                    {
+                        VMC_PRNT(" %s       %s  %s  NA  NA \n\r",(sensorRecord[idx].sensor_name),
+                            (sensorRecord[idx].sensor_value),
+                            ((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal)
+                            ? "Ok":"Error"));
+                    }
+                    else
+                    {
+                        u8 stringLen = (sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK);
+                        VMC_PRNT(" %s       ",(sensorRecord[idx].sensor_name),
+                            ((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal)
+                            ? "Ok":"Error"));
+                        for(stringCount = 0; stringCount< stringLen ; stringCount++)
+                        {
+                            VMC_PRNT("%x",sensorRecord[idx].sensor_value[stringCount]);
+                        }
+                        VMC_PRNT("  %s  NA  NA \n\r",                   ((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal)
+                            ? "Ok":"Error"));
+                    }
+                }
+                else if((sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK) < 4)
+                {
 
-			VMC_PRNT(" %s		%d		%s	%d	%d \n\r",(sensorRecord[idx].sensor_name),
-					*((u16 *)sensorRecord[idx].sensor_value),
-					((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal) ? "Ok":"Error"),
-					*((u16 *)(sensorRecord[idx].sensorMaxValue)),
-					*((u16 *)(sensorRecord[idx].sensorAverageValue)));
+                    VMC_PRNT(" %s       %d      %s  %d  %d \n\r",(sensorRecord[idx].sensor_name),
+                            *((u16 *)sensorRecord[idx].sensor_value),
+                            ((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal) ? "Ok":"Error"),
+                            *((u16 *)(sensorRecord[idx].sensorMaxValue)),
+                            *((u16 *)(sensorRecord[idx].sensorAverageValue)));
 
-		}
-		else if((sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK) == sizeof(u32))
-		{
+                }
+                else if((sensorRecord[idx].sensor_value_type_length & LENGTH_BITMASK) == sizeof(u32))
+                {
 
-			VMC_PRNT(" %s		%d		%s	%d	%d \n\r",(sensorRecord[idx].sensor_name),
-				*((u32 *)sensorRecord[idx].sensor_value),
-				((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal) ? "Ok":"Error"),
-				*((u32 *)(sensorRecord[idx].sensorMaxValue)),
-				*((u32 *)(sensorRecord[idx].sensorAverageValue)));
-		}
-	    }
-	}
+                    VMC_PRNT(" %s       %d      %s  %d  %d \n\r",(sensorRecord[idx].sensor_name),
+                        *((u32 *)sensorRecord[idx].sensor_value),
+                        ((sensorRecord[idx].sensor_status == Vmc_Snsr_State_Normal) ? "Ok":"Error"),
+                        *((u32 *)(sensorRecord[idx].sensorMaxValue)),
+                        *((u32 *)(sensorRecord[idx].sensorAverageValue)));
+                }
+            }
+        }
     }
 
     VMC_PRNT("\n\r");
@@ -1319,66 +1322,66 @@ void AsdmSensor_Display(void)
 
 u8 Asdm_Send_I2C_Sensors_SC(u8 *scPayload)
 {
-	u8 i = 0;
-	u8 dataIndex = 0;
-	u8 sensorSize = 0;
-	s8 tempSensorIdx = getSDRIndex(TemperatureSDR);
-	if(tempSensorIdx < 0)
-	{
-	    VMC_ERR("Failed to Get TemperatureSDR Index\n\r");
-	    return 0;
-	}
+    u8 i = 0;
+    u8 dataIndex = 0;
+    u8 sensorSize = 0;
+    s8 tempSensorIdx = getSDRIndex(TemperatureSDR);
+    if(tempSensorIdx < 0)
+    {
+        VMC_ERR("Failed to Get TemperatureSDR Index\n\r");
+        return 0;
+    }
 
-	if(false == asdmInitSuccess)
-	{
-	    VMC_ERR("Asdm not yet Initialized !! \n\r");
-	    return 0;
-	}
+    if(false == asdmInitSuccess)
+    {
+        VMC_ERR("Asdm not yet Initialized !! \n\r");
+        return 0;
+    }
 
-	Asdm_SensorRecord_t *sensorRecord = sdrInfo[tempSensorIdx].sensorRecord;
-	/* We need to Send all the Temperature sensors to SC for OOB */
-	for(i = 0 ; i< sdrInfo[tempSensorIdx].header.no_of_records; i++)
-	{
-	    /* We do not need send VCCINT_TEMP to SC,
- 	       as we are receiving it from SC
-	    */
-	    if(eSC_VCCINT_TEMP == sensorRecord[i].mspSensorId)
-	    {
-		continue;
-	    }
-	    //Add SC sensor Index for the Sensor
-	    scPayload[dataIndex++] = sensorRecord[i].mspSensorId;
+    Asdm_SensorRecord_t *sensorRecord = sdrInfo[tempSensorIdx].sensorRecord;
+    /* We need to Send all the Temperature sensors to SC for OOB */
+    for(i = 0 ; i< sdrInfo[tempSensorIdx].header.no_of_records; i++)
+    {
+        /* We do not need send VCCINT_TEMP to SC,
+           as we are receiving it from SC
+        */
+        if(eSC_VCCINT_TEMP == sensorRecord[i].mspSensorId)
+        {
+            continue;
+        }
+        //Add SC sensor Index for the Sensor
+        scPayload[dataIndex++] = sensorRecord[i].mspSensorId;
 
-	    //Add Size of the Sensor
-	    sensorSize = (sensorRecord[i].sensor_value_type_length & LENGTH_BITMASK);
-	    scPayload[dataIndex++] = sensorSize;
+        //Add Size of the Sensor
+        sensorSize = (sensorRecord[i].sensor_value_type_length & LENGTH_BITMASK);
+        scPayload[dataIndex++] = sensorSize;
 
-	    // Add Sensor Value
-	    Cl_SecureMemcpy(&scPayload[dataIndex],sensorSize,sensorRecord[i].sensor_value,sensorSize);
+        // Add Sensor Value
+        Cl_SecureMemcpy(&scPayload[dataIndex],sensorSize,sensorRecord[i].sensor_value,sensorSize);
 
-	    dataIndex += sensorSize;
+        dataIndex += sensorSize;
 
-	}
-	return dataIndex;
+    }
+    return dataIndex;
 }
 
 void Asdm_Update_Active_MSP_sensor()
 {
-	s8 boardInfoSensorIdx = getSDRIndex(BoardInfoSDR);
-	s8 idx = 0;
+    s8 boardInfoSensorIdx = getSDRIndex(BoardInfoSDR);
+    s8 idx = 0;
 
-	Asdm_SensorRecord_t *sensorRecord = sdrInfo[boardInfoSensorIdx].sensorRecord;
-	for(idx = sdrInfo[boardInfoSensorIdx].header.no_of_records -1 ; idx >= 0 ; idx--)
-	{
-		if(!Cl_SecureMemcmp(sensorRecord[idx].sensor_name,SENSOR_NAME_MAX,SNSRNAME_ACTIVE_SC_VER,strlen(SNSRNAME_ACTIVE_SC_VER)))
-		{
-			if (xSemaphoreTake(sdr_lock, portMAX_DELAY))
-			{
-				Cl_SecureMemcpy(sensorRecord[idx].sensor_value,sizeof(sc_vmc_data.scVersion),
-						&sc_vmc_data.scVersion[0],sizeof(sc_vmc_data.scVersion));
-				xSemaphoreGive(sdr_lock);
-				break;
-			}
-		}
-	}
+    Asdm_SensorRecord_t *sensorRecord = sdrInfo[boardInfoSensorIdx].sensorRecord;
+    for(idx = sdrInfo[boardInfoSensorIdx].header.no_of_records -1 ; idx >= 0 ; idx--)
+    {
+        if(!Cl_SecureMemcmp(sensorRecord[idx].sensor_name,SENSOR_NAME_MAX,SNSRNAME_ACTIVE_SC_VER,strlen(SNSRNAME_ACTIVE_SC_VER)))
+        {
+            if (xSemaphoreTake(sdr_lock, portMAX_DELAY))
+            {
+                Cl_SecureMemcpy(sensorRecord[idx].sensor_value,sizeof(sc_vmc_data.scVersion),
+                        &sc_vmc_data.scVersion[0],sizeof(sc_vmc_data.scVersion));
+                xSemaphoreGive(sdr_lock);
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
-Use sdr_lock to lock until updating all ASDM sensor values 
-Report sensor status "Vmc_Snsr_State_Comms_failure" for comm failure for some of v70 sensors
-Fix tab indentation 

Major changes (excluding indentation) are in the following functions:

**sdr_lock**:
1. Update_Sensor_Value()         vmc_asdm.c    ln#400     // removed sdr_lock from here
2. Asdm_Update_Sensors()       vmc_asdm.c    ln#1202   // moved sdr_lock to here

**ASDM sensor reading:**
1. Update_Sensor_Value()   vmc_asdm.c  ln#412 // Checking for sensors Vmc_Snsr_State_Normal before adding them to samples
2. V70_Power_Monitor()     v70.c    ln#294
3. V70_Asdm_Read_Power()     v70.c    ln#354
4. V70_Asdm_Read_Voltage_12v()    v70.c    ln#371
5. V70_Asdm_Read_Voltage_3v3()    v70.c    ln#388
6. V70_Asdm_Read_Current_12v()    v70.c    ln#404
7. V70_Asdm_Read_Current_3v3()    v70.c    ln#420
8. V70_Asdm_Read_Current_Vccint()     v70.c    ln#436

Signed-off-by: Shahab Alilou <shahaba@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1145637 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

-----------------------------------------------
[0000:01:00.1] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Electrical
  Max Power              : NA Watts
  Power                  : 15 Watts
  Power Warning          : NA

  Power Rails            : Voltage   Current
  vccint                 :  0.699 V,  2.900 A
  12v_pex                : 12.232 V,  1.100 A
  3v3_pex                :  3.280 V,  0.659 A

### xbtest


STATUS    :: CMN_049 :: MEMORY       :: DDR_INTER :: Test duration reached
INFO      :: MEM_040 :: MEMORY       :: DDR_INTER :: Channel  | Tag        | Write BW (MBps) | Read BW (MBps) | Write latency (ns) | Read latency (ns) | Data integ.
INFO      :: MEM_040 :: MEMORY       :: DDR_INTER :: 0        | MC_NOC1    | 6072.813        | 6071.809       | 191.8              | 318.3             | OK
INFO      :: MEM_040 :: MEMORY       :: DDR_INTER :: 1        | MC_NOC1    | 6072.813        | 6071.813       | 195.7              | 339.2             | OK
INFO      :: MEM_040 :: MEMORY       :: DDR_INTER :: combined | all        | 12145.627       | 12143.621      | 193.7              | 328.7             | OK
PASS      :: MEM_026 :: MEMORY       :: DDR_INTER :: Bandwidth and latency test pass for each of 2 channel(s)
PASS      :: MEM_024 :: MEMORY       :: DDR_INTER :: Data integrity test pass for each of 2 channel(s)
PASS      :: CMN_033 :: MEMORY       :: DDR_INTER :: End Test: 1
STATUS    :: CMN_049 :: MEMORY       :: DDR_SINGLE :: Test duration reached
INFO      :: MEM_040 :: MEMORY       :: DDR_SINGLE :: Channel  | Tag        | Write BW (MBps) | Read BW (MBps) | Write latency (ns) | Read latency (ns) | Data integ.
INFO      :: MEM_040 :: MEMORY       :: DDR_SINGLE :: 0        | MC_NOC0    | 6873.805        | 6868.385       | 139.0              | 283.9             | OK
PASS      :: MEM_026 :: MEMORY       :: DDR_SINGLE :: Bandwidth and latency test pass
PASS      :: MEM_024 :: MEMORY       :: DDR_SINGLE :: Data integrity test pass
PASS      :: CMN_033 :: MEMORY       :: DDR_SINGLE :: End Test: 1
STATUS    :: CMN_048 :: POWER        ::         6 seconds remaining ; Temperature: 90 C; Power: 30.0 W; Toggle rate: 10.0 %
PASS      :: CMN_011 :: MEMORY       :: DDR_SINGLE :: Test/task finished successfully at Fri Dec 02 12:08:19 2022 EST
PASS      :: CMN_011 :: MEMORY       :: DDR_INTER :: Test/task finished successfully at Fri Dec 02 12:08:19 2022 EST
STATUS    :: CMN_048 :: POWER        ::         5 seconds remaining ; Temperature: 90 C; Power: 30.0 W; Toggle rate: 10.0 %
STATUS    :: CMN_048 :: POWER        ::         4 seconds remaining ; Temperature: 90 C; Power: 24.0 W; Toggle rate: 10.0 %
STATUS    :: CMN_048 :: POWER        ::         3 seconds remaining ; Temperature: 90 C; Power: 24.0 W; Toggle rate: 10.0 %
STATUS    :: CMN_048 :: POWER        ::         2 seconds remaining ; Temperature: 90 C; Power: 24.0 W; Toggle rate: 10.0 %
STATUS    :: CMN_048 :: POWER        ::         1 seconds remaining ; Temperature: 90 C; Power: 24.0 W; Toggle rate: 10.0 %
STATUS    :: CMN_049 :: POWER        :: Test duration reached
PASS      :: CMN_033 :: POWER        :: End Test: 1
PASS      :: CMN_011 :: POWER        :: Test/task finished successfully at Fri Dec 02 12:08:25 2022 EST
INFO      :: CMN_007 :: DEVICE_MGMT  :: Stop received
INFO      :: CMN_007 :: VERIFY       :: Stop received
INFO      :: MGT_008 :: DEVICE_MGMT  :: Sensor reading duration summary:
INFO      :: MGT_009 :: DEVICE_MGMT  ::         * [0, 1] sec: 309
INFO      :: MGT_009 :: DEVICE_MGMT  ::         * [1, 2] sec: 0
INFO      :: MGT_009 :: DEVICE_MGMT  ::         * [2, 3] sec: 0
INFO      :: MGT_009 :: DEVICE_MGMT  ::         * [3, 4] sec: 0
INFO      :: MGT_009 :: DEVICE_MGMT  ::         * [4, 5] sec: 0
INFO      :: MGT_009 :: DEVICE_MGMT  ::         * > 5 sec: 0
INFO      :: MGT_009 :: DEVICE_MGMT  ::         * > 10 sec alarm: 0
PASS      :: CMN_011 :: DEVICE_MGMT  :: Test/task finished successfully at Fri Dec 02 12:08:26 2022 EST
PASS      :: CMN_011 :: VERIFY       :: Test/task finished successfully at Fri Dec 02 12:08:26 2022 EST
INFO      :: GEN_040 :: GENERAL      :: ############################################## SUMMARY ##############################################
INFO      :: GEN_017 :: GENERAL      :: XBTEST:
INFO      :: GEN_017 :: GENERAL      ::          - Version     : 6.1.0
INFO      :: GEN_017 :: GENERAL      ::          - SW Build    : 3706343 on Thu Nov 24 09:32:07 2022
INFO      :: GEN_017 :: GENERAL      ::          - Process ID  : 2610
INFO      :: GEN_017 :: GENERAL      ::          - Command line: /opt/xilinx/xbtest/6/bin/xbtest -d 0000:01:00.1 -j /opt/xilinx/xbtest/lib/xilinx-v70-gen5x8-qdma-base-2/test/stress.json -x /opt/xilinx/xbtest/lib/xilinx-v70-gen5x8-qdma-base-2/xclbin/xbtest_stress.xclbin -e /opt/xilinx/xbtest/lib/xilinx-v70-gen5x8-qdma-base-2/xbtest_pfm_def.json -F
INFO      :: GEN_017 :: GENERAL      :: #####################################################################################################
INFO      :: GEN_040 :: GENERAL      :: End of session at: Fri Dec 02 12:08:28 2022 EST
INFO      :: GEN_017 :: GENERAL      :: #####################################################################################################
INFO      :: GEN_018 :: GENERAL      :: Testcases memory DDR_INTER global_config parameters:
INFO      :: GEN_018 :: GENERAL      ::         - test_sequence:
INFO      :: GEN_018 :: GENERAL      ::                  * Test 1: "duration": 300, "mode": "alternate_wr_rd" ; Result: PASSED
PASS      :: GEN_022 :: GENERAL      :: memory DDR_INTER test passed
INFO      :: GEN_018 :: GENERAL      :: #####################################################################################################
INFO      :: GEN_018 :: GENERAL      :: Testcases memory DDR_SINGLE global_config parameters:
INFO      :: GEN_018 :: GENERAL      ::         - test_sequence:
INFO      :: GEN_018 :: GENERAL      ::                  * Test 1: "duration": 300, "mode": "alternate_wr_rd" ; Result: MC_NOC0 PASSED
PASS      :: GEN_022 :: GENERAL      :: memory DDR_SINGLE MC_NOC0 test passed
INFO      :: GEN_018 :: GENERAL      :: #####################################################################################################
INFO      :: GEN_018 :: GENERAL      :: Testcases power global_config parameters:
INFO      :: GEN_018 :: GENERAL      ::         - test_sequence:
INFO      :: GEN_018 :: GENERAL      ::                  * Test 1: "duration": 300, "toggle_rate": 10 ; Result: PASSED
PASS      :: GEN_022 :: GENERAL      :: power test passed
INFO      :: GEN_018 :: GENERAL      :: #####################################################################################################
INFO      :: GEN_040 :: GENERAL      :: 1 Warnings, 2 Critical Warnings, 31 Passes, 0 Errors, 0 Failures encountered
INFO      :: GEN_040 :: GENERAL      :: #####################################################################################################
PASS      :: GEN_024 :: GENERAL      :: RESULT: ALL TESTS PASSED
INFO      :: GEN_018 :: GENERAL      :: ############################################### DONE ################################################

#### Documentation impact (if any)
