### PR TITLE
Fix for CR-1146500

### DIFF
--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -239,6 +239,12 @@ static int clk_throttling_handle(cl_msg_t *msg, struct xgq_cmd_sq *sq)
 			(u32)sq->clk_scaling_payload.pwr_scaling_ovrd_limit;
 	msg->clk_scaling_payload.temp_scaling_ovrd_limit =
 			(u8) sq->clk_scaling_payload.temp_scaling_ovrd_limit;
+	msg->clk_scaling_payload.temp_ovrd_en =
+			(u8) sq->clk_scaling_payload.temp_ovrd_en;
+	msg->clk_scaling_payload.pwr_ovrd_en =
+			(u8) sq->clk_scaling_payload.pwr_ovrd_en;
+	msg->clk_scaling_payload.reset =
+			(u8) sq->clk_scaling_payload.reset;
 
 	return 0;
 }
@@ -318,6 +324,10 @@ static void clk_throttling_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
 				scaling_params.limits.shutdown_limit_pwr;
 	cmd_cq->cq_clk_scaling_payload.pwr_scaling_limit = 
 				scaling_params.limits.throttle_limit_pwr;
+	cmd_cq->cq_clk_scaling_payload.temp_ovrd_en =
+				scaling_params.temp_throttling_enabled;
+	cmd_cq->cq_clk_scaling_payload.pwr_ovrd_en =
+				scaling_params.power_throttling_enabled;
 }
 
 static void vmr_identify_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -223,7 +223,10 @@ struct xgq_cmd_clk_scaling_payload {
 	uint32_t scaling_en:1;
 	uint32_t pwr_scaling_ovrd_limit:16;
 	uint32_t temp_scaling_ovrd_limit:8;
-	uint32_t rsvd1:4;
+	uint32_t reset:1;
+	uint32_t pwr_ovrd_en:1;
+	uint32_t temp_ovrd_en:1;
+	uint32_t rsvd1:1;
 };
 
 /**
@@ -311,7 +314,9 @@ struct xgq_cmd_cq_clk_scaling_payload {
 	uint8_t has_clk_scaling:1;
 	uint8_t clk_scaling_mode:2;
 	uint8_t clk_scaling_en:1;
-	uint8_t rsvd:4;
+	uint8_t pwr_ovrd_en:1;
+	uint8_t temp_ovrd_en:1;
+	uint8_t rsvd:2;
 	uint8_t temp_shutdown_limit;
 	uint8_t temp_scaling_limit;
 	uint16_t pwr_shutdown_limit;

--- a/vmr/src/include/cl_msg.h
+++ b/vmr/src/include/cl_msg.h
@@ -158,7 +158,10 @@ struct xgq_vmr_clk_scaling_payload {
 	uint32_t scaling_en:1;
 	uint32_t pwr_scaling_ovrd_limit:16;
 	uint32_t temp_scaling_ovrd_limit:8;
-	uint32_t rsvd1:4;
+    	uint32_t reset:1;
+   	uint32_t pwr_ovrd_en:1;
+    	uint32_t temp_ovrd_en:1;
+    	uint32_t rsvd1:1;
 };
 
 struct xgq_vmr_head {


### PR DESCRIPTION
	- This patch allows users to enable and disable power/temp override values individually.
	- Also added reset variable to change power/temp override values to default values.

Signed-off-by : Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1146500
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how request additional testing if necessary
Able to set and reset power /temp override values with XRT commands. 
https://github.com/Xilinx/XRT/pull/7184 
#### Documentation impact (if any)
