### PR TITLE
adjust bdf to full path name, requested by VMR pipeline script

### DIFF
--- a/build/build.json
+++ b/build/build.json
@@ -1,5 +1,5 @@
 {
-  "CONF_BUILD_TA" : "2022.2_1202_1",
+  "CONF_BUILD_TA" : "2022.2_1119_1",
   "CONF_BUILD_XSA" : "/opt/xilinx/platforms/xilinx_vck5000_gen4x8_qdma_2_202220_1/hw/xilinx_vck5000_gen4x8_qdma_2_202220_1.xsa",
   "CONF_BUILD_XSABIN" : "/opt/xilinx/firmware/vck5000/gen4x8-qdma/base/partition.xsabin",
   "CONF_BUILD_PLATFORM" : "platform_2022.1_vitis.json",

--- a/build/build.sh
+++ b/build/build.sh
@@ -36,11 +36,10 @@ default_env() {
 	echo -ne "no xsct, using version: "
 	echo "=== TA: ${TA}"
 
-	echo "skip TA setting for now, enable it when boardfarm can resolve the issue"
-#	if [ ! -z ${TA} ];then
-#		echo "TA: ${TA} is set by env, enforce building from the TA"
-#		BUILD_TA=${TA}
-#	fi
+	if [ ! -z ${TA} ];then
+		echo "TA: ${TA} is set by env, enforce building from the TA"
+		BUILD_TA=${TA}
+	fi
 
 	if [ -z $BUILD_TA ];then
 		echo "DEFAULT_VITIS: $DEFAULT_VITIS"


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Veena request this.

```
Veena Sheela
  [10:32 AM](https://xilinx.slack.com/archives/D03B52WHRM2/p1670005979239299)
Can you please fix it to take full bdf, when the fix is ready, we can enable 'vmr upgrade without usb connections' support in vmr pipeline

David Zhang
  [10:34 AM](https://xilinx.slack.com/archives/D03B52WHRM2/p1670006079344239)
I can do that. It may take me a little while to parse the full bdf. Is the full pdf more stable than 65, or it is just easy for your script with less error-prone?

Veena Sheela
  [10:35 AM](https://xilinx.slack.com/archives/D03B52WHRM2/p1670006149883149)
It will be consistent, right now we are using full bdf everywhere. Would be good to have even upgrade_vmr to use full bdf
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
