### PR TITLE
Added Code Coverage feature in UT

### DIFF
--- a/vmr/src/vmc/ut/Makefile
+++ b/vmr/src/vmc/ut/Makefile
@@ -21,6 +21,11 @@ INCLUDE_DIR = $(VMR_MAIN)/vmr/src/vmc/sensors/inc \
     
 TARGET = run_test
 
+#Code Coverage reports
+COV_OUT_DIR  = Cov_Report
+COV_INFO     = Cov.info
+COV_INFO_ALL = Cov_all.info
+
 #Add '-I' as prefix for include directories
 INCLUDE = $(foreach dir, $(INCLUDE_DIR), $(addprefix -I, $(dir)))
 
@@ -33,6 +38,13 @@ LDFLAGS	= -L$(CMOCKA_DIR)/build/src/ -Wl,-rpath=$(CMOCKA_DIR)/build/src/
 LDFLAGS += $(foreach MOCK,$(MOCKS),-Wl,--wrap=$(MOCK))
 LDFLAGS += -lcmocka
 
+#Code coverage flags for the compiler
+COVFLAGS = -fprofile-arcs -ftest-coverage 
+
+#Code Coverage Flags
+COV_DATA = $(patsubst %.c, %.gcda, $(COV_SRC)) \
+          $(patsubst %.c, %.gcno, $(COV_SRC))
+
 OBJS = $(patsubst %.c, %.o, $(SRC))
 
 CC = gcc
@@ -41,17 +53,27 @@ all : $(TARGET)
 
 ifdef TEST_DIR
 $(TARGET) : $(OBJS)
-	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS)
+	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS) $(COVFLAGS)
 
 %.o : %.c
-	$(CC) -o $@ -c $^ $(INCLUDE)
+	$(CC) -o $@ -c $^ $(INCLUDE) $(COVFLAGS)
 else
         $(info ERROR : TEST_DIR not Defined)
         $(info usage on cl: "make TEST_DIR=test/vmc/<test_directory>")
         $(error Make file exit at compilation)
 endif
 
+#Below target generates code coverage report
+.PHONY : lcov 
+lcov : $(COV_INFO)
+	genhtml $(COV_INFO) --output-directory $(COV_OUT_DIR)
+	
+$(COV_INFO) : $(COV_DATA)
+	lcov --capture --directory $(VMR_MAIN) --output-file $(COV_INFO_ALL)
+	lcov --remove $(COV_INFO_ALL) -output-file $(COV_INFO) '$(ROOT_DIR)/*'
+
 .PHONY : clean
 clean : 
-	rm $(OBJS) $(TARGET)
+	rm $(OBJS) $(TARGET) $(COV_DATA) $(COV_INFO_ALL) $(COV_INFO) $(COV_OUT_DIR) -r
+	find ./ -type f -name '*.gc*' -delete
 

--- a/vmr/src/vmc/ut/test/vmc/asdm/unittest.mk
+++ b/vmr/src/vmc/ut/test/vmc/asdm/unittest.mk
@@ -15,6 +15,10 @@ SRC += $(VMR_MAIN)/vmr/src/vmc/vmc_asdm.c \
        $(ROOT_DIR)/mocks/vmc/utm_vmc_main.c \
        $(ROOT_DIR)/mocks/vmc/utm_vmc_update_sc.c \
        $(ROOT_DIR)/mocks/vmc/utm_clock_throttling.c
+       
+#Source code for which code coverage report will be generated
+COV_SRC = $(VMR_MAIN)/vmr/src/vmc/vmc_asdm.c \
+          $(VMR_MAIN)/vmr/src/vmc/platforms/v70.c
 
 MOCKS += Cl_SecureMemcpy \
 	 Cl_SecureMemset \

--- a/vmr/src/vmc/ut/test/vmc/sensor/se98a/unittest.mk
+++ b/vmr/src/vmc/ut/test/vmc/sensor/se98a/unittest.mk
@@ -2,6 +2,8 @@ SRC += $(VMR_MAIN)/vmr/src/vmc/sensors/src/se98a.c \
        $(ROOT_DIR)/mocks/common/utm_cl_i2c.c \
        $(ROOT_DIR)/test/vmc/sensor/se98a/utt_se98a.c 
 
+#Source code for which code coverage report will be generated
+COV_SRC = $(VMR_MAIN)/vmr/src/vmc/sensors/src/se98a.c
 
 MOCKS += i2c_send_rs_recv
 


### PR DESCRIPTION
    - Added commands in Makefile to generate code coverage reports for test files using 'lcov' tool

Signed-off-by: K Thirukumaran <thirukumaran.k@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
NA
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
No
#### What has been tested and how, request additional testing if necessary
NA
#### Documentation impact (if any)
https://confluence.xilinx.com/display/DCG/UT_Framework