### PR TITLE
Fix for CR-1145360

### DIFF
--- a/vmr/src/include/cl_vmc.h
+++ b/vmr/src/include/cl_vmc.h
@@ -53,4 +53,5 @@ void cl_vmc_get_clk_throttling_params(clk_throttling_params_t *params);
 int cl_vmc_clk_throttling_disable();
 int cl_vmc_clk_throttling_enable();
 int cl_vmc_has_sc_version(void);
+u8 cl_clk_throttling_enabled_or_disabled ();
 #endif

--- a/vmr/src/include/vmr_common.h
+++ b/vmr/src/include/vmr_common.h
@@ -127,6 +127,7 @@
 #define APU_SHARED_MEMORY_ADDR(offset) (VMR_EP_APU_SHARED_MEMORY_START + (u32)offset)
 
 #define SHUTDOWN_LATCHED_STATUS	0x01
+#define MAX_GAPPING_DEMAND_RATE 128
 
 #define BIT(n) 			(1UL << (n))
 #define MIN(x, y) 		(((x) < (y)) ? (x) : (y))

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -636,4 +636,7 @@ int cl_vmc_sysmon_init()
 	return cl_vmc_sysmon_is_ready();
 }
 
+u8 cl_clk_throttling_enabled_or_disabled (){
 
+	return g_clk_throttling_params.clk_scaling_enable;
+}


### PR DESCRIPTION
	-Added changes to show clock throttled percentage message in dmesg

Signed-off-by: Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1145360
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Added changes to show clock throttled percentage message in dmesg
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Tested with the custom XRT build(Just a Hack). Able to see log message in dmesg when clock throttling enabled.
#### Documentation impact (if any)
NA