### PR TITLE
reset payload_size in case of making host prints too many faked dmesg

### DIFF
--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -683,6 +683,9 @@ static u32 rmgmt_check_firewall(cl_msg_t *msg)
 
 		/* set correct size in result payload */
 		msg->log_payload.size = MIN(count, safe_size);
+	} else {
+		/* explicitly set log_payload.size back to 0 */
+		msg->log_payload.size = 0;
 	}
 
 	return val;
@@ -731,6 +734,8 @@ static u32 rmgmt_log_clock_shutdown(cl_msg_t *msg)
 		{
 			msg->log_payload.size = safe_size;
 		}
+	} else {
+		msg->log_payload.size = 0;
 	}
 
 	return val;


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
