### PR TITLE
VMC : Remove MAC Count override

### DIFF
--- a/vmr/src/vmc/vmc_api.c
+++ b/vmr/src/vmc/vmc_api.c
@@ -470,9 +470,6 @@ u8 Versal_EEPROM_ReadBoardInfo(void)
 		status = Update_BoardInfo_Data(i2c_num, &board_info.Num_MAC_IDS,
 				eeprom_offset[eEeprom_Board_Tot_Mac_Id].offset,
 				eeprom_offset[eEeprom_Board_Tot_Mac_Id].size);
-		if (board_info.Num_MAC_IDS == 0) {
-			board_info.Num_MAC_IDS = 1;
-		}
 	} else {
 		board_info.Num_MAC_IDS = eeprom_offset[eEeprom_Board_Tot_Mac_Id].size;
 	}


### PR DESCRIPTION
V70 does not MACs, do not override the mac count field in VMC, if eeprom reads out 0, it's expected.
This issue was seen because the code was written based on, an incorrectly programmed EEPROM, in an ES Card.

Signed-off-by: Sandeep Kumar Thakur <sandeep.thakur@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
V70 does not MACs, do not override the mac count field in VMC, if eeprom reads out 0, it's expected.
This issue was seen because the code was written based on, an incorrectly programmed EEPROM, in an ES Card.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1148103](https://jira.xilinx.com/browse/CR-1148103)

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary

```
Product Name   : ALVEO V70 ES2
Board Rev      : A
Board Serial   : 51171A226N0X
MAC ID Number  : 0               <---------------------
Board MAC0     : 00:00:00:00:00:00
Board MAC1     : 00:00:00:00:00:00
EEPROM Version : 3.0
Board A/P      : P
Board Config   : 08
PCIe Info      : 10ee, 5004, 10ee, 00ee
UUID           : bcb49f77-890a-5180-db42-09ef07fab207
Memory Size    : 16G
MFG DATE       : 768ed4
PART NUM       : 05117-01
OEM ID         : 000010da
Capability     : 00a7
FW Ver         : 8.5.2
BSL vendor ver : 0100
BSL CI ver     : 0400
BSL API ver    : 0800
BSL PI ver     : 0600
BSL build ID   : 0019
```

#### Documentation impact (if any)
