### PR TITLE
Fix for CR-1149168 inconsistent xgq_cmd_vmr.h and xgq_cmd_common.h

### DIFF
--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -240,9 +240,9 @@ static int clk_throttling_handle(cl_msg_t *msg, struct xgq_cmd_sq *sq)
 	msg->clk_scaling_payload.temp_scaling_ovrd_limit =
 			(u8) sq->clk_scaling_payload.temp_scaling_ovrd_limit;
 	msg->clk_scaling_payload.temp_ovrd_en =
-			(u8) sq->clk_scaling_payload.temp_ovrd_en;
+			(u8) sq->clk_scaling_payload.temp_scaling_ovrd_en;
 	msg->clk_scaling_payload.pwr_ovrd_en =
-			(u8) sq->clk_scaling_payload.pwr_ovrd_en;
+			(u8) sq->clk_scaling_payload.pwr_scaling_ovrd_en;
 	msg->clk_scaling_payload.reset =
 			(u8) sq->clk_scaling_payload.reset;
 
@@ -324,9 +324,9 @@ static void clk_throttling_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
 				scaling_params.limits.shutdown_limit_pwr;
 	cmd_cq->cq_clk_scaling_payload.pwr_scaling_limit = 
 				scaling_params.limits.throttle_limit_pwr;
-	cmd_cq->cq_clk_scaling_payload.temp_ovrd_en =
+	cmd_cq->cq_clk_scaling_payload.temp_scaling_ovrd_en =
 				scaling_params.temp_throttling_enabled;
-	cmd_cq->cq_clk_scaling_payload.pwr_ovrd_en =
+	cmd_cq->cq_clk_scaling_payload.pwr_scaling_ovrd_en =
 				scaling_params.power_throttling_enabled;
 }
 

--- a/vmr/src/common/xgq_cmd_common.h
+++ b/vmr/src/common/xgq_cmd_common.h
@@ -79,6 +79,7 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_ACCESS_VALID     	= 0x10d,
 	XGQ_CMD_OP_DATA_INTEGRITY   	= 0x10e,
 	XGQ_CMD_OP_EXIT             	= 0x10f,
+	XGQ_CMD_OP_UNCFG_CU	        = 0x110,
 
 	/* Common command type */
 	XGQ_CMD_OP_BARRIER		= 0x200,

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -212,9 +212,12 @@ struct xgq_cmd_vmr_control_payload {
  * @aid: Clock scaling API ID which decides API in VMC.
  *          0x1 - READ_CLOCK_THROTTLING_CONFIGURATION
  *          0x2 - SET_CLOCK_THROTTLING_CONFIGURATION
- * @scaling_enable: enable or disable flag
- * @pwr_ovrd: power override value
- * @temp_ovrd: temperature override value
+ * @scaling_en: enable or disable flag
+ * @pwr_scaling_ovrd_limit: set power override value
+ * @temp_scaling_ovrd_limit: set temperature override value
+ * @reset: reset the clock scaling configs to defaults
+ * @pwr_scaling_ovrd_en: power override enable/disable flag
+ * @temp_scaling_ovrd_en: temperature override enable/disable flag
  *
  * This payload is used for clock scaling configuration report.
  */
@@ -224,8 +227,8 @@ struct xgq_cmd_clk_scaling_payload {
 	uint32_t pwr_scaling_ovrd_limit:16;
 	uint32_t temp_scaling_ovrd_limit:8;
 	uint32_t reset:1;
-	uint32_t pwr_ovrd_en:1;
-	uint32_t temp_ovrd_en:1;
+	uint32_t pwr_scaling_ovrd_en:1;
+	uint32_t temp_scaling_ovrd_en:1;
 	uint32_t rsvd1:1;
 };
 
@@ -308,14 +311,22 @@ struct xgq_cmd_cq_data_payload {
 /**
  * struct xgq_cmd_cq_clk_scaling_payload: clock scaling status payload
  *
- * clock scaling status
+ * @has_clk scaling: shows if the platform support clock scaling feature
+ * @clk_scaling_mode: which clock scaling mode enabled currently
+ * @clk_scaling_en: shows if clock scaling is enabled (1) or disabled (0)
+ * @pwr_scaling_ovrd_en: power scaling override is enabled or not
+ * @temp_scaling_ovrd_en: temperature scaling override is enabled or not
+ * @temp_shutdown_limit: temperature shutdown limit
+ * @temp_scaling_limit: temperature scaling override value set
+ * @pwr_shutdown_limit: power shutdown limit
+ * @pwr_scaling_limit: power scaling override value set
  */
 struct xgq_cmd_cq_clk_scaling_payload {
 	uint8_t has_clk_scaling:1;
 	uint8_t clk_scaling_mode:2;
 	uint8_t clk_scaling_en:1;
-	uint8_t pwr_ovrd_en:1;
-	uint8_t temp_ovrd_en:1;
+	uint8_t pwr_scaling_ovrd_en:1;
+	uint8_t temp_scaling_ovrd_en:1;
 	uint8_t rsvd:2;
 	uint8_t temp_shutdown_limit;
 	uint8_t temp_scaling_limit;


### PR DESCRIPTION
Signed-off-by : Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
With this PR xgq_cmd_vmr.h and xgq_cmd_common.h are same across both XRT and VMR repo .  
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1147558



