### PR TITLE
additional fix for CR-1147558 clock throttling percentage in the dmesg

### DIFF
--- a/vmr/src/include/vmr_common.h
+++ b/vmr/src/include/vmr_common.h
@@ -128,6 +128,8 @@
 
 #define SHUTDOWN_LATCHED_STATUS	0x01
 #define MAX_GAPPING_DEMAND_RATE 128
+#define CONVERT_TO_PERCENTAGE  100
+#define MAX_CLOCK_SPEED_PERCENTAGE 100
 
 #define BIT(n) 			(1UL << (n))
 #define MIN(x, y) 		(((x) < (y)) ? (x) : (y))

--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -762,8 +762,10 @@ static u8 rmgmt_log_clock_throttling_percentage(cl_msg_t *msg)
 				msg->log_payload.size, rh.rh_log_max_size);
 			safe_size = msg->log_payload.size;
 		}
-
-		count = snprintf(rh.rh_log, safe_size,"kernel clocks throttled at %lu%%.\n",(ep_gapping * 100)/max_gapping_demand_rate);
+		/* To get % clock throttled = 100 - total clock running %
+ 		 * total clock running % = (current clock speed / maximum clock speed) * 100 	  
+ 		 */  
+		count = snprintf(rh.rh_log, safe_size,"kernel clocks throttled at %lu%%.\n",MAX_CLOCK_SPEED_PERCENTAGE - ((ep_gapping * CONVERT_TO_PERCENTAGE)/max_gapping_demand_rate));
 		cl_memcpy_toio(dst_addr, rh.rh_log, safe_size);
 
 		/* set correct size in result payload */


### PR DESCRIPTION
	As per older alveo cards printing out the percentage that the clock was reduced by
	not the total percentage of the clock being used.

Signed-off-by: Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1145360
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Enabled clock scaling , Able to see clock scaling % log in dmesg
#### Documentation impact (if any)
