### PR TITLE
Fix for CR-1150866 , CR-1150870

### DIFF
--- a/vmr/src/vmc/clock_throttling.c
+++ b/vmr/src/vmc/clock_throttling.c
@@ -33,7 +33,7 @@ float Moving_Average(Moving_Average_t * av_obj, float new_element)
 		av_obj->is_filled = true;
 	}
 	/* return the average */
-	return av_obj->sum / (av_obj->is_filled ? av_obj->length:av_obj->pos);
+	return av_obj->sum / (float)(av_obj->is_filled ? av_obj->length:av_obj->pos);
 }
 
 Moving_Average_t *Allocate_Moving_Average(u8 len)

--- a/vmr/src/vmc/clock_throttling.h
+++ b/vmr/src/vmc/clock_throttling.h
@@ -138,7 +138,7 @@ typedef enum {
 typedef struct __attribute__((packed)) Moving_Average_s
 {
 	float * buffer;
-	long sum;
+	float sum;
 	u8 pos;
 	u8 length;
 	bool is_filled;

--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -276,7 +276,7 @@ void getSDRMetaData(Asdm_Sensor_MetaData_t **pMetaData, u16 *sdrMetaDataCount)
     {
         .repoType = CurrentSDR,
         .getSensorName = &getCurrentNames,
-        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_2B,
+        .snsrValTypeLength = SENSOR_TYPE_NUM | SENSOR_SIZE_4B,
         .snsrUnitModifier = -3,
         .supportedThreshold = SNSR_MAX_VAL | SNSR_AVG_VAL ,
         .sampleCount = 0x1,

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -152,7 +152,7 @@ s8 Temperature_Read_ACAP_Device_Sysmon(snsrRead_t *snsrData)
 	s8 status = XST_FAILURE;
 	float TempReading = 0.0;
 
-	status = XSysMonPsv_ReadTempProcessed(&InstancePtr, XSYSMONPSV_TEMP_MAX, &TempReading);
+	status = XSysMonPsv_ReadTempProcessed(&InstancePtr, XSYSMONPSV_TEMP, &TempReading);
 	if (status == XST_SUCCESS)
 	{
 		u16 roundedOffVal = (TempReading > 0) ? TempReading : 0;
@@ -164,7 +164,7 @@ s8 Temperature_Read_ACAP_Device_Sysmon(snsrRead_t *snsrData)
 	else
 	{
 		snsrData->snsrSatus = Vmc_Snsr_State_Comms_failure;
-		VMC_DBG("Failed to read Sysmon : %d \n\r",XSYSMONPSV_TEMP_MAX);
+		VMC_DBG("Failed to read Sysmon : %d \n\r",XSYSMONPSV_TEMP);
 	}
 
 	if (TempReading >= TEMP_FPGA_CRITICAL_THRESHOLD)
@@ -267,7 +267,7 @@ void sysmon_monitor(void)
 {
 
 	float TempReading = 0.0;
-	if (XSysMonPsv_ReadTempProcessed(&InstancePtr, XSYSMONPSV_TEMP_MAX, &TempReading))
+	if (XSysMonPsv_ReadTempProcessed(&InstancePtr, XSYSMONPSV_TEMP, &TempReading))
 	{
 		CL_LOG(APP_VMC, "Failed to read sysmon temperature \n\r");
 		sensor_glvr.sensor_readings.sysmon_max_temp = -1.0;


### PR DESCRIPTION
	- Incorrectly reading Sysmon max temp , changed it to read sysmon current temp.
	- Moving average sum changed to float to aviod type casting issues.
	- Assigned 4bytes for vccint current reading , to send it through ASDM.

 Signed-off-by : Vamshi Krishnan Gaddam <vgaddam@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1150866
https://jira.xilinx.com/browse/CR-1150870
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
```Able to see the changes in device temp after xbtest finished 
/opt/xilinx/xrt/bin/xbutil examine -r thermal -d 86:00.1 
-----------------------------------------------
[0000:86:00.1] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Thermals
  Temperature            : Celcius
  PCB                    :     43 C
**device                 :     54 C**
  vccint                 :     50 C 

  root@xhddcslab03:/tmp# /opt/xilinx/xrt/bin/xbutil examine -r thermal -d 86:00.1 
  -----------------------------------------------
[0000:86:00.1] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Thermals
  Temperature            : Celcius
  PCB                    :     43 C  
**device                 :     54 C**
  vccint                 :     50 C 
  
  root@xhddcslab03:/tmp# /opt/xilinx/xrt/bin/xbutil examine -r thermal -d 86:00.1 
  -----------------------------------------------
[0000:86:00.1] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Thermals
  Temperature            : Celcius
  PCB                    :     43 C 
**device                 :     53 C**
  vccint                 :     49 C 
  
  root@xhddcslab03:/tmp# /opt/xilinx/xrt/bin/xbutil examine -r thermal -d 86:00.1 
  -----------------------------------------------
[0000:86:00.1] : xilinx_v70_gen5x8_qdma_base_2
-----------------------------------------------
Thermals
  Temperature            : Celcius
  PCB                    :     42 C
 **device                 :     52 C**
  vccint                 :     48 C
  ```

#### Documentation impact (if any)
