### PR TITLE
Copying .pdi files as well to VMR_ELF location

### DIFF
--- a/docker/vmr_setup_build.sh
+++ b/docker/vmr_setup_build.sh
@@ -19,4 +19,4 @@ md5sum *.elf
 source /proj/xbuilds/${TA}/installs/lin64/Vitis/HEAD/settings64.sh
 
 #Copy VMR.elf file to NFS location
-mkdir -p /proj/xbuilds/VMR-ELF/${RELEASE}/${BUILD_NUMBER} && cp *.elf /proj/xbuilds/VMR-ELF/${RELEASE}/${BUILD_NUMBER}
+mkdir -p /proj/xbuilds/VMR-ELF/${RELEASE}/${BUILD_NUMBER} && cp *.elf *.pdi /proj/xbuilds/VMR-ELF/${RELEASE}/${BUILD_NUMBER}


### PR DESCRIPTION

Copying .pdi files as well to VMR_ELF location for supporting v70 Board hosts to test the below requirement from boardfarm team

Boardfarm team requirement: We have couple of V70 hosts ready to be added in vmr pipeline. Since, these hosts doesn't have USB connected, there are some code changes needed in pipeline_cmd infra to use the correct command to live upgrade vmr without usb connections

@dayeh-xilinx @xdavidz 

