### PR TITLE
Copying upgrade_vmr.sh to NFS location

### DIFF
--- a/docker/vmr_setup_build.sh
+++ b/docker/vmr_setup_build.sh
@@ -20,3 +20,4 @@ source /proj/xbuilds/${TA}/installs/lin64/Vitis/HEAD/settings64.sh
 
 #Copy VMR.elf file to NFS location
 mkdir -p /proj/xbuilds/VMR-ELF/${RELEASE}/${BUILD_NUMBER} && cp *.elf *.pdi /proj/xbuilds/VMR-ELF/${RELEASE}/${BUILD_NUMBER}
+mkdir -p /proj/xbuilds/VMR/${RELEASE}/${BUILD_NUMBER} && cp upgrade_vmr.sh /proj/xbuilds/VMR/${RELEASE}/${BUILD_NUMBER}


### PR DESCRIPTION

Copying upgrade_vmr.sh to NFS location to support the usecase of getting upgrade_vmr.sh from the PR itself 

@xdavidz 