### PR TITLE
CR-1153211 set RTOS task depth based on peak memory usage

### DIFF
--- a/vmr/src/common/cl_main.c
+++ b/vmr/src/common/cl_main.c
@@ -28,9 +28,10 @@
  * use vmr_mem_status to check peak usage in certain load.
  * the current peak usage is < 2k, seting thread to 16k heap size.
  *  The thread Depth "number of words" of the stack.
- *  depth (4k) * sizeof(word) = total size (16k)
+ *  depth (12k) * sizeof(word) = total size (48k)
+ * If we have 5 tasks, it takes up to 240k.
  */
-#define TASK_STACK_DEPTH 	0x1000
+#define TASK_STACK_DEPTH 	0x3000
 
 /*
  * VMR (Versal Management Runtime) design diagram.


### PR DESCRIPTION
Signed-off-by: David Zhang <davidzha@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

For V80 or Foraker, we need to trim the task smaller for better scale the VMR.
Currently, we set it to 256k bytes which is not ideal. 
I run "xbutil examin" for 24 hours and collected the peak usage of vmr tasks, and also calculate current usage by each task.
A safer size is 4k ~ 8k for now, so we set to 16k for future improvement and decent room. Tested on V70.
Note: the number reported by FreeRTOS is in 32bit word, thus 4069 * 4 = 16k.
 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
