### PR TITLE
CR-1153077_xgq_cmd_common_file_sync 

### DIFF
--- a/vmr/src/common/xgq_cmd_common.h
+++ b/vmr/src/common/xgq_cmd_common.h
@@ -85,6 +85,7 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_BARRIER		= 0x200,
 	XGQ_CMD_OP_EXIT_ERT		= 0x201,
 	XGQ_CMD_OP_IDENTIFY		= 0x202,
+	XGQ_CMD_OP_TIMESET		= 0x204,
 };
 
 enum xgq_cmd_addr_type {
@@ -269,7 +270,7 @@ struct xgq_cmd_configure {
 };
 
 /**
- * struct xgq_cmd_indentify: identify command
+ * struct xgq_cmd_identify: identify command
  *
  * @hdr: header of the command
  *
@@ -281,7 +282,7 @@ struct xgq_cmd_identify {
 };
 
 /**
- * struct xgq_cmd_resp_indentify: identify command response
+ * struct xgq_cmd_resp_identify: identify command response
  *
  * @minor: minor version of the XGQ command set
  * @major: major version of the XGQ command set
@@ -297,6 +298,28 @@ struct xgq_cmd_resp_identify {
 		};
 		uint32_t result;
 	};
+	uint32_t resvd;
+	uint32_t rcode;
+};
+
+/**
+ * struct xgq_cmd_timeset: timeset command
+ *
+ * @hdr: header of the command
+ *
+ * This command is used to set Linux system time
+ */
+struct xgq_cmd_timeset {
+	struct xgq_cmd_sq_hdr  hdr;
+	int64_t ts;
+};
+
+/**
+ * struct xgq_cmd_resp_indentify: timeset command response
+ */
+struct xgq_cmd_resp_timeset {
+	struct xgq_cmd_cq_hdr  hdr;
+	uint32_t result;
 	uint32_t resvd;
 	uint32_t rcode;
 };


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Header file matching.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified xgq_cmd_common.h file in VMR to match one to one against same file in XRT for recent updates.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on VCK5000 and build log says no mismatch and diff.log is clean.
Tested sanity of vmr.elf on VCK5000 and found good functionality.
![image](https://user-images.githubusercontent.com/111782805/224400959-7c8ec14b-04dc-416e-94b9-dfbf2f1369b7.png)


#### Documentation impact (if any)
