### PR TITLE
ALVEO-12190: Fix incorrect printing of max power

### DIFF
--- a/vmr/src/vmc/vmc_api.c
+++ b/vmr/src/vmc/vmc_api.c
@@ -366,9 +366,9 @@ static void Print_Eeprom_3_0(void)
 								  board_info.OEM_ID[0]);
 
 
-	VMR_PRNT( "Max Power Mode        : %x ", board_info.board_max_power_mode);
-	VMR_PRNT( "Memory size           : %s ", board_info.Memory_size);
-	VMR_PRNT( "Capabilities          : %02x%02x ", board_info.capability[0], board_info.capability[1]);
+	VMR_PRNT( "Max Power Mode        : %d \n\r", board_info.board_max_power_mode[0]);
+	VMR_PRNT( "Memory size           : %s \n\r", board_info.Memory_size);
+	VMR_PRNT( "Capabilities          : %02x%02x \n\r", board_info.capability[0], board_info.capability[1]);
 }
 
 static bool Verify_Checksum(void)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Fix for https://jira.xilinx.com/browse/ALVEO-12190 incorrect printing of max power

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Manual inspection of code

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary



![image](https://user-images.githubusercontent.com/105228050/227262643-c030814b-7bc8-4f1d-bee0-d256935aa2f2.png)


#### Documentation impact (if any)
