### PR TITLE
Fix for CR-1158076

### DIFF
--- a/vmr/src/vmc/clock_throttling.c
+++ b/vmr/src/vmc/clock_throttling.c
@@ -292,6 +292,13 @@ void clock_throttling_algorithm(Clock_Throttling_Handle_t* pContext, bool Readin
 	{
 		pContext->Activity = ACTIVITY_MAX;
 	}
+	/*
+	 *The below condition is limit the clock speed to 5%
+	 *when override values are less than the idle readings.
+	 *
+ 	*/	
+	if (pContext->Activity < REDUCE_GAPPING_DEMAND_RATE_TO_FIVE_PERCENTAGE)
+		pContext->Activity = REDUCE_GAPPING_DEMAND_RATE_TO_FIVE_PERCENTAGE;
 
 	VMC_DBG(" %d 	%d	%f	%f \n\r",pContext->Activity,(pContext->BoardMeasuredPower)/1000000,pContext->FPGAMeasuredTemp,pContext->VccIntMeasuredTemp);
 	IO_SYNC_WRITE32(pContext->Activity | MASK_CLOCKTHROTTLING_ENABLE_THROTTLING, VMR_EP_GAPPING_DEMAND);

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -40,7 +40,6 @@
 #define ENABLE_FORCE_SHUTDOWN   0x000DB190
 
 #define WATTS_TO_MICROWATTS (1000000)
-#define REDUCE_GAPPING_DEMAND_RATE_TO_FIVE_PERCENTAGE 0x07
 static int vmc_sysmon_is_ready = 0;
 /* TODO: init those to a certain value */
 static XSysMonPsv InstancePtr;

--- a/vmr/src/vmc/vmc_sensors.h
+++ b/vmr/src/vmc/vmc_sensors.h
@@ -19,6 +19,7 @@
 
 #define POWER_MODE_300W 3
 #define LPD_I2C_0	0x1
+#define REDUCE_GAPPING_DEMAND_RATE_TO_FIVE_PERCENTAGE 0x07
 
 typedef enum {
 	e12V_PEX = 0,


### PR DESCRIPTION
	- current implementation of clock throttling is reducing clock speed to zero when override values are less than the idle readings. This is causing firewall trips on the host side. To avoid that, limit clock speed to 5% instead of zero.

Signed-off-by: Vamshi Krishnan Gaddam <vgaddam@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1158076
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
Not seeing crash after enabling clock throttling with lower temperature and power values.
xbutil validate got succeeded. 
#### Documentation impact (if any)
