### PR TITLE
v70: Updated Board info structure members similar to SC

### DIFF
--- a/vmr/src/vmc/platforms/v70.c
+++ b/vmr/src/vmc/platforms/v70.c
@@ -203,8 +203,58 @@ s32 V70_VMC_Fetch_BoardInfo(u8 *board_snsr_data)
 
     (void)VMC_Get_BoardInfo(&board_info);
 
-    Cl_SecureMemcpy(board_snsr_data, sizeof(Versal_BoardInfo), &board_info, sizeof(Versal_BoardInfo));
-    byte_count = sizeof(Versal_BoardInfo);
+    /* copy data in the order of SC BordInfo structure */
+    Cl_SecureMemcpy(board_snsr_data, sizeof(board_info.product_name), &board_info.product_name[0], sizeof(board_info.product_name));
+    byte_count += sizeof(board_info.product_name);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_rev), &board_info.board_rev[0], sizeof(board_info.board_rev));
+    byte_count += sizeof(board_info.board_rev);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_serial), &board_info.board_serial[0], sizeof(board_info.board_serial));
+    byte_count += sizeof(board_info.board_serial);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.eeprom_version), &board_info.eeprom_version[0], sizeof(board_info.eeprom_version));
+    byte_count += sizeof(board_info.eeprom_version);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_mac), &board_info.board_mac[0], sizeof(board_info.board_mac));
+    byte_count += sizeof(board_info.board_mac);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_act_pas), &board_info.board_act_pas[0], sizeof(board_info.board_act_pas));
+    byte_count += sizeof(board_info.board_act_pas);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_config_mode), &board_info.board_config_mode[0], sizeof(board_info.board_config_mode));
+    byte_count += sizeof(board_info.board_config_mode);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_mfg_date), &board_info.board_mfg_date[0], sizeof(board_info.board_mfg_date));
+    byte_count += sizeof(board_info.board_mfg_date);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_part_num), &board_info.board_part_num[0], sizeof(board_info.board_part_num));
+    byte_count += sizeof(board_info.board_part_num);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_uuid), &board_info.board_uuid[0], sizeof(board_info.board_uuid));
+    byte_count += sizeof(board_info.board_uuid);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_pcie_info), &board_info.board_pcie_info[0], sizeof(board_info.board_pcie_info));
+    byte_count += sizeof(board_info.board_pcie_info);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.board_max_power_mode), &board_info.board_max_power_mode[0], sizeof(board_info.board_max_power_mode));
+    byte_count += sizeof(board_info.board_max_power_mode);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.Memory_size), &board_info.Memory_size[0], sizeof(board_info.Memory_size));
+    byte_count += sizeof(board_info.Memory_size);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.OEM_ID), &board_info.OEM_ID[0], sizeof(board_info.OEM_ID));
+    byte_count += sizeof(board_info.OEM_ID);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.DIMM_size), &board_info.DIMM_size[0], sizeof(board_info.DIMM_size));
+    byte_count += sizeof(board_info.DIMM_size);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.Num_MAC_IDS), &board_info.Num_MAC_IDS, sizeof(board_info.Num_MAC_IDS));
+    byte_count += sizeof(board_info.Num_MAC_IDS);
+
+    Cl_SecureMemcpy(board_snsr_data + byte_count, sizeof(board_info.capability), &board_info.capability[0], sizeof(board_info.capability));
+    byte_count += sizeof(board_info.capability);
+
 
     /* Check and return -1 if size of response is > 256 */
     return ((byte_count <= MAX_VMC_SC_UART_BUF_SIZE) ? (byte_count) : (-1));


### PR DESCRIPTION
	- Vmc sends board info to SC . So changed Versal_BoardInfo stucture same as SC.

Signed-off-by : Vamshi Krishnan Gaddam <vagaddam@amd.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1166660

https://github.com/Xilinx/VMR/commit/f68a58580f10e81e5304077b3ce9c313aa47dd2f

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
------------------------------------------------
Product Name   : ALVEO V70 ES3
Board Rev      : B
Board Serial   : XFL1LMNPB0KR
MAC ID Number  : 0
Board MAC0     : ff:ff:ff:ff:ff:ff
Board MAC1     : 00:00:00:00:00:00
EEPROM Version : 3.0
Board A/P      : P
Board Config   : 08
PCIe Info      : 10ee, 5094, 10ee, 000e
UUID           : e837f5ed-1c9b-50a7-1243-8e9aa6763531
Memory Size    : 16G
MFG DATE       : 77d9d9
PART NUM       : 05117-01ES
OEM ID         : 000010da
Capability     : 0000
FW Ver         : 8.5.2
BSL vendor ver : 0100
BSL CI ver     : 0400
BSL API ver    : 0800
BSL PI ver     : 0600
BSL build ID   : 0019
------------------------------------------------

#### Documentation impact (if any)
