### PR TITLE
TA set to 2023.1 for base 3

### DIFF
--- a/build/build_v70.json
+++ b/build/build_v70.json
@@ -1,6 +1,6 @@
 {
-  "CONF_BUILD_TA" : "2022.2_daily_latest",
-  "CONF_BUILD_XSA" : "/opt/xilinx/platforms/xilinx_v70_gen5x8_qdma_2_202220_1/hw/xilinx_v70_gen5x8_qdma_2_202220_1.xsa",
+  "CONF_BUILD_TA" : "2023.1_daily_latest",
+  "CONF_BUILD_XSA" : "/opt/xilinx/platforms/xilinx_v70_gen5x8_qdma_3_202310_1/hw/xilinx_v70_gen5x8_qdma_3_202310_1.xsa",
   "CONF_BUILD_XSABIN" : "/opt/xilinx/firmware/v70/gen5x8-qdma/base/partition.xsabin",
   "CONF_BUILD_PLATFORM" : "platform_2022.1_vitis.json",
   "CONF_BUILD_JTAG" : "0",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
modified the build_v70.json file to set the TA from 2022.2  to 2023.1 and changed to base 3 shell.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
