### PR TITLE
ALVEO-13319: Initialization of RMI handler

### DIFF
--- a/vmr/src/common/cl_rmi.c
+++ b/vmr/src/common/cl_rmi.c
@@ -155,14 +155,31 @@ static s8 rmi_sensor_init(void)
     return ret_val;
 }
 
+/**
+*  @brief Callback registered with RMI to respond to API requests
+*  @param req Request buffer - incoming API request from RMI
+*  @param req_size Size of request buffer
+*  @param res Response buffer - returned to RMI
+*  @param res_size Size of response buffer
+*  @return 0 on success
+*/
+int8_t rmi_request(uint8_t* req, uint16_t* req_size, uint8_t* res, uint16_t* res_size)
+{
+    //TODO
+    return 0;
+}
+
 /*
 *  @brief Calls initializes rmi library. It is called from cl_main
 *  @return
 */
 int cl_rmi_init(void)
 {
+    rmi_config_t rmi_config = { .rmi_malloc_fptr = pvPortMalloc, .rmi_request_fptr = rmi_request, .rmi_free_fptr = vPortFree,
+                                .rmi_memcpy_fptr = Cl_SecureMemcpy, .rmi_memset_fptr = Cl_SecureMemset, .rmi_memcmp_fptr = Cl_SecureMemcmp,
+                                .rmi_memmove_fptr = Cl_SecureMemmove, .rmi_strncpy_fptr = Cl_SecureStrncpy, .rmi_strncmp_fptr = Cl_SecureStrncmp };
 
-    rmi_init();
+    lRmiInitialize(rmi_config);
 
     is_rmi_ready = true;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

Build only. With 23.1 and xilinx_v70smbus_gen5x8_qdma_2_202310_1.xsa and xilinx_v70_gen5x8_qdma_3_202310_1.xsa

#### Documentation impact (if any)

Code is only active if BUILD_FOR_RMI is defined i.e. changes have no impact otherwise. The build will fail if BUILD_FOR_RMI is defined since requisite work has to be completed in ALVEO-13318 first.
