### PR TITLE
CR-1172429 UUID Check Bypass Fix

### DIFF
--- a/vmr/src/rmgmt/rmgmt_xfer.c
+++ b/vmr/src/rmgmt/rmgmt_xfer.c
@@ -344,7 +344,10 @@ static int rmgmt_fpga_download(struct rmgmt_handler *rh, u32 len)
 	ret = rmgmt_get_uuids((u32)axlf, (char *)xclbin_int_uuid);
 	if (ret) {
 		VMR_ERR("Failed to find UUID from xclbin");
-		return -EINVAL;
+		/* Assuming that file with no UUID means incoming file is PS Kernel xclbin in which case UUID check is skipped
+		 * Failure of a valid xclbin with UUID needs handling here in case if necessary
+		 */
+		goto skip_uuid;
 	}
 
     	if (rmgmt_fpt_get_xsabin(&msg, &fdtdata, &fdtdata_size)) {
@@ -371,7 +374,7 @@ static int rmgmt_fpga_download(struct rmgmt_handler *rh, u32 len)
 		VMR_DBG("xsa:0x%s", xsabin_int_uuid);
 		VMR_WARN("Interface UUID Match Found!");
 	}
-
+skip_uuid:
 	ret = rmgmt_xclbin_section_info(axlf, CLOCK_FREQ_TOPOLOGY, &offset, &size);
 	if (ret || size == 0) {
 		VMR_LOG("no CLOCK TOPOLOGY from xclbin: %d", ret);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is to remove the UUID check in VMR while loading xclbin; the PS Kernel xclbin does not have uuid and this PR handles this case.

#### How problem was solved, alternative solutions (if any) and why they were rejected
UUID comparison is skipped in rmgmt.

#### Risks (if any) associated the changes in the commit
These changes examine and forward xclbin to APU irrespective of the incoming file.
If a UUID is not found in a NON-PS kernel xclbin, this edge case not handled but this is not needed for current functionality that VMR should support.

#### What has been tested and how, request additional testing if necessary
Tested to check if existing VMR flow works and xbutil validate to load normal xclbin UUID is working.
Second case includes testing PS Kernel xclbin and bypass is working.
The Dmesg for second case throws error which is expected because, work on APU Petalinux over PS kernel is still in progress which is linked to the error. while this PR is recorded.

#### Documentation impact (if any)
