### PR TITLE
ALVEO-13322: Parse GET_SDR API

### DIFF
--- a/vmr/src/vmc/rmi.c
+++ b/vmr/src/vmc/rmi.c
@@ -6,6 +6,7 @@
 
 #include "FreeRTOS.h"
 #include "RMI/rmi_api.h"
+#include "RMI/rmi_sensors.h"
 #include "rmi.h"
 #include "vmc_asdm.h"
 #include "cl_mem.h"
@@ -15,7 +16,7 @@ rmi_error_codes_t xGet_Sdr_Api(uint8_t **pucPayload, uint16_t *pusPayload_Size)
 {
     rmi_error_codes_t xErr = eRMI_SUCCESS;
     uint8_t ucMax_Repo_Count = Get_Asdm_SDR_Repo_Size();
-    uint16_t usPayload_Size = sizeof(Rmi_asdm_header_t);
+    uint16_t usPayload_Size = sizeof(rmi_asdm_header_t);
     uint8_t *pucBuffer = NULL;
 
     if( NULL == pucPayload || NULL == pusPayload_Size )
@@ -26,9 +27,9 @@ rmi_error_codes_t xGet_Sdr_Api(uint8_t **pucPayload, uint16_t *pusPayload_Size)
     {
         uint32_t ulTotal_records = 0;
 
-        for( int i = 0; i < ucMax_Repo_Count; ++i )
+        for( int i = 1; i < ucMax_Repo_Count; ++i )
         {
-            usPayload_Size += sdrInfo[i].header.no_of_records * sizeof(Rmi_asdm_sdr_t);
+            usPayload_Size += sdrInfo[i].header.no_of_records * sizeof(rmi_asdm_sdr_t);
             ulTotal_records += sdrInfo[i].header.no_of_records;
         }
 
@@ -44,18 +45,19 @@ rmi_error_codes_t xGet_Sdr_Api(uint8_t **pucPayload, uint16_t *pusPayload_Size)
 
             size_t xOffset = 0;
 
-            Rmi_asdm_header_t xTemp_Header = { 0 };
-            Rmi_asdm_sdr_t xTemp_Sensor = { 0 };
+            rmi_asdm_header_t xTemp_Header = { 0 };
+            rmi_asdm_sdr_t xTemp_Sensor = { 0 };
 
-            xTemp_Header.repository_type = RmiSDR;
+            xTemp_Header.repository_type = eRmiSDR;
             xTemp_Header.repository_version = 0x00;
+            xTemp_Header.no_of_bytes = usPayload_Size;
             xTemp_Header.no_of_records = ulTotal_records;
 
             Cl_SecureMemcpy(pucBuffer, usPayload_Size, &xTemp_Header, sizeof(xTemp_Header));
 
-            xOffset += sizeof(Rmi_asdm_header_t);
+            xOffset += sizeof(rmi_asdm_header_t);
 
-            for(int i = 0; i < ucMax_Repo_Count; ++i)
+            for(int i = 1; i < ucMax_Repo_Count; ++i)
             {
                 for(int j = 0; j < sdrInfo[i].header.no_of_records; ++j)
                 {
@@ -73,10 +75,14 @@ rmi_error_codes_t xGet_Sdr_Api(uint8_t **pucPayload, uint16_t *pusPayload_Size)
                     Cl_SecureMemcpy(xTemp_Sensor.sensor_value, ucSensorvalue_Size, sdrInfo[i].sensorRecord[j].sensor_value, ucSensorvalue_Size);
 
                     xTemp_Sensor.sensor_base_unit_type_length = sdrInfo[i].sensorRecord[j].sensor_base_unit_type_length;
-                    uint8_t ucSensorbase_Size = xTemp_Sensor.sensor_value_type_length;
-                    xTemp_Sensor.sensor_base_unit = pvPortMalloc(ucSensorbase_Size);
-                    Cl_SecureMemcpy(xTemp_Sensor.sensor_base_unit, ucSensorbase_Size, sdrInfo[i].sensorRecord[j].sensor_base_unit, ucSensorbase_Size);
 
+                    if( NULL != sdrInfo[i].sensorRecord[j].sensor_base_unit )
+                    {
+                        uint8_t ucSensorbase_Size = xTemp_Sensor.sensor_value_type_length;
+                        xTemp_Sensor.sensor_base_unit = pvPortMalloc(ucSensorbase_Size);
+                        Cl_SecureMemcpy(xTemp_Sensor.sensor_base_unit, ucSensorbase_Size, sdrInfo[i].sensorRecord[j].sensor_base_unit, ucSensorbase_Size);
+
+                    }
 
                     xTemp_Sensor.sensor_unit_modifier_byte = sdrInfo[i].sensorRecord[j].sensor_unit_modifier_byte;
                     xTemp_Sensor.threshold_support_byte = sdrInfo[i].sensorRecord[j].threshold_support_byte;
@@ -120,6 +126,8 @@ rmi_error_codes_t xGet_Sdr_Api(uint8_t **pucPayload, uint16_t *pusPayload_Size)
                     xTemp_Sensor.sensor_status = sdrInfo[i].sensorRecord[j].sensor_status;
 
                     Cl_SecureMemcpy(pucBuffer + xOffset, sizeof(xTemp_Sensor), &xTemp_Sensor, sizeof(xTemp_Sensor));
+                    Cl_SecureMemset(&xTemp_Sensor, 0, sizeof(xTemp_Sensor));
+
                     xOffset += sizeof(xTemp_Sensor);
                 }
             }
@@ -132,13 +140,7 @@ rmi_error_codes_t xGet_Sdr_Api(uint8_t **pucPayload, uint16_t *pusPayload_Size)
     return xErr;
 }
 
-rmi_error_codes_t xGet_All_Sensor_Data_Api(void)
-{
-    //TODO
-    return eRMI_SUCCESS;
-}
-
-rmi_error_codes_t xRmi_Request_Handler(uint8_t* pucReq, uint16_t* pusReq_size, uint8_t* pucResp, uint16_t* pusResp_size)
+rmi_error_codes_t xRmi_Request_Handler(uint8_t* pucReq, uint16_t* pusReq_size, uint8_t** pucResp, uint16_t* pusResp_size)
 {
     rmi_error_codes_t xErr = eRMI_ERROR_GENERIC;
     uint8_t ucApi_id = 0;
@@ -153,25 +155,24 @@ rmi_error_codes_t xRmi_Request_Handler(uint8_t* pucReq, uint16_t* pusReq_size, u
 
             switch( ucApi_id )
             {
-                case ASDM_CMD_GET_SDR_API_ID:
+                case RMI_CMD_GET_SDR_API_ID:
 
                     xErr = xGet_Sdr_Api( &pucPayload, &usPayload_Size );
 
                     if( eRMI_SUCCESS == xErr )
                     {
                         //TODO Change so pucResp is allocated by RMI
-                        uint8_t *pucResp = pvPortMalloc( usPayload_Size + RMI_API_RESPONSE_HEADER_SIZE );
+                        *pucResp = pvPortMalloc( usPayload_Size + RMI_API_RESPONSE_HEADER_SIZE );
 
                         if( NULL != pucResp )
                         {
-                            pucResp[RMI_API_ID_INDEX] = ucApi_id;
-                            //TODO Add named completion codes to RMI
-                            pucResp[RMI_API_COMPLETION_CODE_INDEX] = 0x01;
-                            pucResp[RMI_API_RESPONSE_REPO_TYPE_INDEX] = RmiSDR;
-                            pucResp[RMI_API_RESPONSE_PAYLOAD_SIZE_LSB] = (uint8_t) usPayload_Size;
-                            pucResp[RMI_API_RESPONSE_PAYLOAD_SIZE_MSB] = (uint8_t) (usPayload_Size >> 8);
-                            Cl_SecureMemcpy(pucResp + RMI_API_RESPONSE_HEADER_SIZE, usPayload_Size, pucPayload, usPayload_Size);
 
+                            (*pucResp)[RMI_API_ID_INDEX] = ucApi_id;
+                            (*pucResp)[RMI_API_COMPLETION_CODE_INDEX] = eRmi_CC_Operation_Success;
+                            (*pucResp)[RMI_API_RESPONSE_REPO_TYPE_INDEX] = eRmiSDR;
+                            (*pucResp)[RMI_API_RESPONSE_PAYLOAD_SIZE_LSB] = (uint8_t) usPayload_Size;
+                            (*pucResp)[RMI_API_RESPONSE_PAYLOAD_SIZE_MSB] = (uint8_t) (usPayload_Size >> 8);
+                            Cl_SecureMemcpy(*pucResp + RMI_API_RESPONSE_HEADER_SIZE, usPayload_Size, pucPayload, usPayload_Size);
                             *pusResp_size = RMI_API_REQUEST_HEADER_SIZE + usPayload_Size;
                         }
                         else
@@ -184,10 +185,8 @@ rmi_error_codes_t xRmi_Request_Handler(uint8_t* pucReq, uint16_t* pusReq_size, u
 
                 break;
 
-                case ASDM_CMD_GET_ALL_SENSOR_DATA_API_ID:
-
-                    xErr = xGet_All_Sensor_Data_Api();
-
+                case RMI_CMD_GET_ALL_SENSOR_DATA_API_ID:
+                        //TODO
                 break;
 
                 default:

--- a/vmr/src/vmc/rmi.h
+++ b/vmr/src/vmc/rmi.h
@@ -20,7 +20,7 @@ extern SDR_t *sdrInfo;
 *  @param pusResp_size Size of response buffer
 *  @return eRMI_SUCCESS on success
 */
-rmi_error_codes_t xRmi_Request_Handler(uint8_t* pucReq, uint16_t* pusReq_size, uint8_t* pucResp, uint16_t* pusResp_size);
+rmi_error_codes_t xRmi_Request_Handler(uint8_t* pucReq, uint16_t* pusReq_size, uint8_t** pucResp, uint16_t* pusResp_size);
 
 rmi_error_codes_t get_SDR_API(uint8_t **pucBuffer, uint16_t *pusBufSize);
 rmi_error_codes_t get_ALL_SENSOR_DATA_API(void);


### PR DESCRIPTION
- Complement of ALVEO-13322 in RMI repo
- Uses updated definitions from RMI

Signed-off-by: Philip Higgins philip.higgins@amd.com

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Uses definitions added to RMI.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Fixed some memory bugs caused by uninitialized memory.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Made use of new definitions.
Initialized memory

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

Compiled using build_smbus_RMI.json in vmr build directory on V70

Sample sensor data printed when compiled with BUILD_FOR_RMI enabled and RMI built from https://github.com/Xilinx/RMI/pull/31

![image](https://github.com/Xilinx/VMR/assets/105228050/0a0a3e98-3c14-4949-8591-6ced8bc08471)


#### Documentation impact (if any)
