### PR TITLE
CR-1173531: Fix missing RMI/rmi_api.h

### DIFF
--- a/vmr/src/vmc/rmi.c
+++ b/vmr/src/vmc/rmi.c
@@ -2,6 +2,7 @@
 * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
+#ifdef BUILD_FOR_RMI
 #include <stdint.h>
 
 #include "FreeRTOS.h"
@@ -209,3 +210,5 @@ rmi_error_codes_t xRmi_Request_Handler(uint8_t* pucReq, uint16_t* pusReq_size, u
 
     return xErr;
 }
+
+#endif /* BUILD_FOR_RMI */

--- a/vmr/src/vmc/rmi.h
+++ b/vmr/src/vmc/rmi.h
@@ -2,6 +2,7 @@
 * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
+#ifdef BUILD_FOR_RMI
 #ifndef RMI_H
 #define RMI_H
 
@@ -26,3 +27,4 @@ rmi_error_codes_t get_SDR_API(uint8_t **pucBuffer, uint16_t *pusBufSize);
 rmi_error_codes_t get_ALL_SENSOR_DATA_API(void);
 
 #endif /* RMI_H */
+#endif /* BUILD_FOR_RMI */


### PR DESCRIPTION
- Wrap rmi.c and rmi.h in #ifdef BUILD_FOR_RMI

Signed-off-by: Philip Higgins philip.higgins@amd.com

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Build error due to missing files found in RMI sub repo

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Missing file

#### How problem was solved, alternative solutions (if any) and why they were rejected

Wrapped erroneous code in BUILD_FOR_RMI ifdef

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

Before fix

![image](https://github.com/Xilinx/VMR/assets/105228050/8b6413c2-82e1-4507-86e9-dc77aef4d825)

After fix

![image](https://github.com/Xilinx/VMR/assets/105228050/4eca23af-2784-4ecc-8bd4-7c81128a0917)

Config used to build

![image](https://github.com/Xilinx/VMR/assets/105228050/fdc62068-ab75-435e-8560-f699bf9aa86f)


#### Documentation impact (if any)
