### PR TITLE
regression found when return -EINVAL instead of -ENOENT for no

### DIFF
--- a/vmr/src/rmgmt/rmgmt_xfer.c
+++ b/vmr/src/rmgmt/rmgmt_xfer.c
@@ -521,7 +521,7 @@ int rmgmt_fdt_get_uuids(u32 fdt_addr, char *int_uuid, u32 uuid_size)
     	ret = rmgmt_xclbin_section_info(axlf, PARTITION_METADATA, &offset, &size);
     	if (ret || size == 0) {
         	VMR_WARN("no PARTITION_METADATA in xclbin: %d", ret);
-		return -EINVAL;
+		return -ENOENT;
     	} else {
         	VMR_DBG("offset %llx", offset);
         	bph = (struct fdt_header *)((char *)axlf + offset);


### PR DESCRIPTION
partition_metadata of softkernel

The logic is a bit not clear now, but given we are releasing the pq2 soon, we don't want to refactor the code too much.
Just return -ENOENT to ignore it for now.

In the future, we should check partition_metdata,
if (true)
   download pdi and bitstream partial pdi
else
   send it to apu as softkernel
