### PR TITLE
Add option to build VMR excluding VMC.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -7,6 +7,7 @@ TOOL_VERSION="2023.1"
 DEFAULT_VITIS="/proj/xbuilds/${TOOL_VERSION}_daily_latest/installs/lin64/Vitis/HEAD/settings64.sh"
 STDOUT_JTAG=2 # 0: uart0; 1: uart1; 2: default to uartlite
 BUILD_XRT=0
+BUILD_VMR_EXCLUDE_VMC=0
 UPDATE_RMI=0
 BUILD_RMI_LIB=0
 ROOT_DIR=`pwd`
@@ -329,8 +330,12 @@ check_vmr()
 
 build_app_all() {
 	cd $ROOT_DIR
-	rsync -a ../vmr/src $BUILD_DIR/vmr_app --exclude cmc --exclude vmc/ut
-
+	
+	if [ $BUILD_VMR_EXCLUDE_VMC -eq 1 ]; then
+        rsync -a ../vmr/src $BUILD_DIR/vmr_app --exclude cmc --exclude vmc
+	else
+	    rsync -a ../vmr/src $BUILD_DIR/vmr_app --exclude cmc --exclude vmc/ut
+	fi
 	RMI=$ROOT_DIR/librmi.a
 	if [ -f $RMI ];then
 		echo "=== Adding RMI lib to build ==="	
@@ -352,7 +357,7 @@ build_app_all() {
 	else
 		cp config_app.tcl $BUILD_DIR
 		cd $BUILD_DIR
-		xsct ./config_app.tcl >> $BUILD_LOG 2>&1
+		xsct ./config_app.tcl $BUILD_VMR_EXCLUDE_VMC >> $BUILD_LOG 2>&1
 	fi
 	
 	cd $ROOT_DIR
@@ -705,6 +710,9 @@ do
 			;;
 		-XRT)
 			BUILD_XRT=1
+			;;
+		-novmc)
+		    BUILD_VMR_EXCLUDE_VMC=1
 			;;
 		-RMI)
 			UPDATE_RMI=1

--- a/build/config_app.tcl
+++ b/build/config_app.tcl
@@ -11,3 +11,9 @@ puts "=== analyze stack usage per function"
 app config -name vmr_app -add compiler-misc -fstack-usage
 puts "=== set warnings if stack is above 4k"
 app config -name vmr_app -add compiler-misc -Wstack-usage=4096
+
+set no_vmc [lindex $argv 0]
+if { $no_vmc == 1 } {
+	puts "=== Enable BUILD_VMR_EXCLUDE_VMC Flag"
+    app config -name vmr_app -add compiler-misc -DBUILD_VMR_EXCLUDE_VMC
+}

--- a/vmr/src/common/cl_uart_rtos.c
+++ b/vmr/src/common/cl_uart_rtos.c
@@ -40,7 +40,9 @@ static int32_t UART_Config(uart_rtos_handle_t *handle, XUartPsv *UartInstPtr,
 
 /************************** Variable Definitions ***************************/
 
+#ifndef BUILD_VMR_EXCLUDE_VMC
 extern SemaphoreHandle_t vmc_debug_logbuf_lock; /* used to block until LogBuf is in use */
+#endif
 
 /************************** Code ******************************************/
 
@@ -668,10 +670,10 @@ s32 UART_RTOS_Debug_Enable(uart_rtos_handle_t *handle, ePlatformType curr_platfo
 
 	debugUartConig.uartHandler = handle;
 
-
+#ifndef BUILD_VMR_EXCLUDE_VMC
 	vmc_debug_logbuf_lock = xSemaphoreCreateMutex();
 	configASSERT(NULL != vmc_debug_logbuf_lock);
-
+#endif
 	return UART_RTOS_Enable(&debugUartConig, curr_platform);
 }
 

--- a/vmr/src/common/cl_vmc_sc_comms.c
+++ b/vmr/src/common/cl_vmc_sc_comms.c
@@ -13,6 +13,7 @@
 #include "cl_vmc.h"
 #include "vmr_common.h"
 
+#ifndef BUILD_VMR_EXCLUDE_VMC
 /*
  *   every 1000ms ---> cl_vmc_sc_update --+<---  go back and recheck <--------+
  *                                        |                                   |
@@ -66,3 +67,4 @@ void cl_vmc_sc_comms_func(void *task_args)
 		vTaskDelay(pdMS_TO_TICKS(1000));
 	}
 }
+#endif

--- a/vmr/src/common/cl_vmc_sensor.c
+++ b/vmr/src/common/cl_vmc_sensor.c
@@ -13,6 +13,7 @@
 #include "cl_vmc.h"
 #include "vmr_common.h"
 
+#ifndef BUILD_VMR_EXCLUDE_VMC
 /*
  * Note: the 2022.1_web flow is the legacy code flow that is revisited and
  *     refactored by newer 2022.2 Resilient VMR new flow. We document legacy
@@ -148,3 +149,4 @@ void cl_vmc_sensor_func(void *task_args)
 		vTaskDelay(pdMS_TO_TICKS(100));
 	}
 }
+#endif

--- a/vmr/src/common/cl_xgq_opcode.c
+++ b/vmr/src/common/cl_xgq_opcode.c
@@ -33,7 +33,7 @@ static int opcode_vmr_control(cl_msg_t *msg)
 {
 	return cl_rmgmt_vmr_control(msg);
 }
-
+#ifndef BUILD_VMR_EXCLUDE_VMC
 static int opcode_vmc_sensor(cl_msg_t *msg)
 {
 	return cl_vmc_sensor_request(msg);
@@ -43,7 +43,7 @@ static int opcode_vmc_clk_throttling(cl_msg_t *msg)
 {
 	return cl_vmc_clk_scaling(msg);
 }
-
+#endif
 static int opcode_vmr_identify(cl_msg_t *msg)
 {
 	//Assuming 0 on a successful event and only one response type for this Command; so cl_vmr_identify() is not defined.
@@ -60,8 +60,10 @@ struct opcode_handle {
 	{"LOG PAGE", CL_MSG_LOG_PAGE, opcode_log_page},
 	{"CLOCK", CL_MSG_CLOCK, opcode_clock},
 	{"VMR CONTROL", CL_MSG_VMR_CONTROL, opcode_vmr_control},
+#ifndef BUILD_VMR_EXCLUDE_VMC
 	{"SENSOR", CL_MSG_SENSOR, opcode_vmc_sensor},
 	{"CLOCK THROTTLING", CL_MSG_CLK_THROTTLING, opcode_vmc_clk_throttling},
+#endif
 	{"VMR IDENTIFY CMD", CL_MSG_VMR_IDENTIFY, opcode_vmr_identify},
 };
 

--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -297,11 +297,16 @@ static void vmr_control_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
 	cmd_cq->cq_vmr_payload.pl_is_ready = cl_rmgmt_pl_is_ready();
 	
 	/* pass back status, SC is ready and VMC has SC version */
+#ifndef BUILD_VMR_EXCLUDE_VMC
 	cmd_cq->cq_vmr_payload.sc_is_ready = cl_vmc_has_sc_version();
-
+	cmd_cq->cq_vmr_payload.program_progress = FLASH_PROGRESS;
+#else
+    //TBD: what should be filed for sc_is_ready?
+	// also check if ospi_flash_progress() is ideal to assign below.
+    cmd_cq->cq_vmr_payload.program_progress = ospi_flash_progress();
+#endif
 	/* pass back log level and flash progress */
 	cmd_cq->cq_vmr_payload.debug_level = cl_loglevel_get();
-	cmd_cq->cq_vmr_payload.program_progress = FLASH_PROGRESS;
 }
 
 static void log_page_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
@@ -312,9 +317,9 @@ static void log_page_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
 static void clk_throttling_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
 {
 	clk_throttling_params_t scaling_params = { 0 };
-
+#ifndef BUILD_VMR_EXCLUDE_VMC
 	cl_vmc_get_clk_throttling_params(&scaling_params);
-
+#endif
 	cmd_cq->cq_clk_scaling_payload.has_clk_scaling = 
 				scaling_params.is_clk_scaling_supported;
 	cmd_cq->cq_clk_scaling_payload.clk_scaling_mode =

--- a/vmr/src/include/cl_uart_rtos.h
+++ b/vmr/src/include/cl_uart_rtos.h
@@ -10,11 +10,12 @@
 #include <FreeRTOS.h>
 #include <event_groups.h>
 #include <semphr.h>
+#include <stdbool.h>
 
 #include "xil_types.h"
 #include "xscugic.h"
 
-#include "../vmc/vmc_api.h"
+#include "cl_vmc.h"
 
 
 #define MAX_LOG_SIZE	(1024u)

--- a/vmr/src/include/cl_vmc.h
+++ b/vmr/src/include/cl_vmc.h
@@ -30,6 +30,13 @@ typedef struct  __attribute__((packed)) {
 	u8 limits_update_req;
 }clk_throttling_params_t;
 
+typedef enum{
+    eVCK5000 = 0, /* VCK5000 or V350, so 2 platforms in one enum*/
+    eV70 = 2,
+    eV80,
+    eMax_Platforms,
+} ePlatformType;
+
 
 int cl_vmc_sensor_request(struct cl_msg *msg);
 int cl_vmc_is_ready(void);

--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -322,7 +322,6 @@ int cl_rmgmt_program_vmr(cl_msg_t *msg)
 static u32 rmgmt_fpt_status_query(cl_msg_t *msg, char *buf, u32 size)
 {
 	u32 count = 0;
-	struct fpt_sc_version version = { 0 };
 
 	rmgmt_fpt_query(msg);
 
@@ -352,7 +351,8 @@ static u32 rmgmt_fpt_status_query(cl_msg_t *msg, char *buf, u32 size)
 		VMR_WARN("msg is truncated");
 		return size;
 	}
-
+#ifndef BUILD_VMR_EXCLUDE_VMC
+    struct fpt_sc_version version = { 0 };
 	(void) cl_vmc_pdi_scfw_version(&version); 
 	count += snprintf(buf + count, size - count, "SCFW image version: %d.%d.%d\n",
 		version.fsv_major, version.fsv_minor, version.fsv_revision);
@@ -360,7 +360,7 @@ static u32 rmgmt_fpt_status_query(cl_msg_t *msg, char *buf, u32 size)
 		VMR_WARN("msg is truncated");
 		return size;
 	}
-
+#endif
 	return count;
 }
 
@@ -708,7 +708,11 @@ static u32 rmgmt_log_clock_shutdown(cl_msg_t *msg)
 
 static u8 rmgmt_log_clock_throttling_percentage(cl_msg_t *msg)
 {
+#ifndef BUILD_VMR_EXCLUDE_VMC
 	u8 val = cl_clk_throttling_enabled_or_disabled();
+#else
+    u8 val = 0;
+#endif
 
 	/*
 	 * copy message back from rh_log to shared memory

--- a/vmr/src/vmc/sensors/src/m24c128.c
+++ b/vmr/src/vmc/sensors/src/m24c128.c
@@ -7,6 +7,7 @@
 #include "cl_log.h"
 #include "cl_i2c.h"
 #include "../inc/m24c128.h"
+#include "../../vmc_api.h"
 
 u8 M24C128_ReadByte(u8 i2c_num, u8 slaveAddr, u16 *AddressOffset,u8 *RegisterValue)
 {

--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -19,6 +19,7 @@
 #include "cl_log.h"
 #include "cl_main.h"
 #include "cl_io.h"
+#include "cl_vmc.h"
 
 #include "vmc_asdm.h"
 
@@ -230,13 +231,6 @@ typedef struct Versal_BoardInfo
 
 #define     MAX_PLATFORM_NAME_LEN (20u)
 #define     MAX_FUNCTION_NAME_LEN (20u)
-
-typedef enum{
-    eVCK5000 = 0, /* VCK5000 or V350, so 2 platforms in one enum*/
-    eV70 = 2,
-    eV80,
-    eMax_Platforms,
-} ePlatformType;
 
 typedef struct __attribute__((packed)) {
     ePlatformType   product_type_id;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added option to build script to build VMR excluding VMC module.
Description of changes made:
1. /build/build_dir/build.sh
- Defined BUILD_VMR_EXCLUDE_VMC which is set when -novmc (exclude vmc) flag is passed as paramter to build.sh
  to exclude VMC from the build process.
- If the BUILD_VMR_EXCLUDE_VMC is set, VMC folder is excluded from copying to build_dir.

2. /build/build_dir/config_app.tcl
- Macro is defined using -DBUILD_VMR_EXCLUDE_VMC option in config_app.tcl when build with -novmc is choosen.

3. /vmr/src/common/cl_main.c
- Initialization of sensor and comms task handles are masked using BUILD_VMR_EXCLUDE_VMC macro.
- Call to vmc init function is masked using BUILD_VMR_EXCLUDE_VMC macro.
- [TBD] Call to cl_queue_create() is moved below. Need confirmation if this can be called after VMC init validation.

4. /vmr/src/common/cl_uart_rtos.c
- VMC debug lock is masked using BUILD_VMR_EXCLUDE_VMC macro.

5. /vmr/src/common/cl_vmc_sc_comms.c
- Entire file is masked using BUILD_VMR_EXCLUDE_VMC macro. I believe this can be moved to VMC folder in future.

6. /vmr/src/common/cl_vmc_sensor.c
- Entire file is masked using BUILD_VMR_EXCLUDE_VMC macro. I believe this can be moved to VMC folder in future.

7. /vmr/src/common/cl_xgq_opcode.c
- VMC specific opcode functions and respective handles are masked using BUILD_VMR_EXCLUDE_VMC macro.

8. /vmr/src/common/cl_xgq_receive.c
- [TBD] payload parameters sc_is_ready and program_progress has confict here. This needs review.
- [TBD] reading throttling parameters is masked under BUILD_VMR_EXCLUDE_VMC macro. Without VMC, these parameters  
  are initialized to 0. Need confirmation if this behavior is expected.
  
9. /vmr/src/include/cl_uart_rtos.h
- replaced "include vmc_api.h" with "include cl_vmc.h". common files do not need dependency with VMC API files.

10./vmr/src/include/cl_vmc.h
- migrated ePlatformType enum from vmc_api.h to cl_vmc.h as this is being used in every module which has to be in common headers.

11./vmr/src/rmgmt/rmgmt_main.c
- Masked VMC version function call using BUILD_VMR_EXCLUDE_VMC macro.

12./vmr/src/vmc/sensors/src/m124c128.c
- VMC structures were earlier imported here using cl_uart_rtos.h. As vmc_api.h is now removed from cl_uart_rtos.h file, 
  vmc_api.h is imported here.
  
13./vmr/src/vmc/vmc_api.h
- imported common cl_vmc.h here to get access to ePlatformType enum.


#### What has been tested and how, request additional testing if necessary
Test Runs:
1. Build VMR/XRT is -novmc option, build went successful.
2. Build VMR/XRT without -novmc option, build went successful.

#### Documentation impact (if any)
Build.sh usage documentation.
