### PR TITLE
Skip system.dtb check as part of extension FPT for RAVE

### DIFF
--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -1276,7 +1276,7 @@ int cl_rmgmt_init( void )
 	else
 	{
         /* system.dtb is not exclusively included as part of FPT for all the platforms */
-		VMR_WARN("Loading system.dtp at 0x%x failed",VMR_EP_SYSTEM_DTB);
+		VMR_WARN(" skip loading system.dtb at 0x%x ",VMR_EP_SYSTEM_DTB);
 	}
 
 	rmgmt_is_ready_flag = true;

--- a/vmr/src/rmgmt/rmgmt_xfer.c
+++ b/vmr/src/rmgmt/rmgmt_xfer.c
@@ -457,7 +457,7 @@ static int rmgmt_ospi_apu_download(struct rmgmt_handler *rh, u32 len)
 		/* system.dtb is not exclusively included as part of Extension FPT for all the platforms.
 		 * Log a warning and continue to load APU package.
 		 */
-		VMR_WARN("Failed to get system.dtp from Extension FPT");
+		VMR_WARN("Failed to get system.dtb from Extension FPT");
 	}
 	/*
 	 * If there is SYSTEM_METADATA section in APU xsabin, then the data is


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
rmgmt_ospi_apu_download() checks for  system.dtb as part of extension FPT before performing APU download.
system.dtb is now included as part of APU and not part of extension FPT, hence skipping this validation
for RAVE boards.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed my skipping the validation specific for RAVE platform.
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
1. Build VMR for both RAVE and Non RAVE platforms to validate the changes are compatible.
2. Flash VMR and validate to see dtb read failure is not shown.

#### Documentation impact (if any)
FPT/APU documentation may need an update related to the existence of system.dtb in respective modules.
