### PR TITLE
CR-1123282 - Use get_size sdr request to receive sensor data size

### DIFF
--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -304,6 +304,12 @@ static void vmr_control_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
 	cmd_cq->cq_vmr_payload.program_progress = FLASH_PROGRESS;
 }
 
+static void sensor_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
+{
+	/* Fill the completion queue with sensor size information */
+	cmd_cq->cq_sensor_payload.sensor_size = msg->sensor_payload.size;
+}
+
 static void log_page_complete(cl_msg_t *msg, struct xgq_cmd_cq *cmd_cq)
 {
 	cmd_cq->cq_log_payload.count = msg->log_payload.size;
@@ -366,7 +372,7 @@ static struct xgq_cmd_handler xgq_cmd_handlers[] = {
 	{XGQ_CMD_OP_VMR_CONTROL, CL_MSG_VMR_CONTROL, "VMR_CONTROL", CL_QUEUE_OPCODE,
 		vmr_control_handle, vmr_control_complete},
 	{XGQ_CMD_OP_SENSOR, CL_MSG_SENSOR, "SENSOR", CL_QUEUE_OPCODE,
-		sensor_handle, NULL},
+		sensor_handle, sensor_complete},
 	{XGQ_CMD_OP_PROGRAM_SCFW, CL_MSG_PROGRAM_SCFW, "PROGRAM SCFW", CL_QUEUE_PROGRAM,
 		NULL, NULL},
 	{XGQ_CMD_OP_CLK_THROTTLING, CL_MSG_CLK_THROTTLING, "CLOCK THROTTLING", CL_QUEUE_OPCODE,

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -298,7 +298,7 @@ struct xgq_cmd_cq_clock_payload {
  */
 struct xgq_cmd_cq_sensor_payload {
 	uint32_t result;
-	uint32_t resvd;
+	uint32_t sensor_size;
 };
 
 /**

--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -910,13 +910,10 @@ s8 Asdm_Get_SDR_Size(u8 *req, u8 *resp, u16 *respSize)
 
     /* Fill the Size of the SDR */
     sdrSize = sizeof(Asdm_Header_t) + (sdrInfo[sdrIndex].header.no_of_bytes * 8);
-
     Cl_SecureMemcpy(&resp[2],sizeof(sdrSize),&sdrSize, sizeof(sdrSize));
-
-    *respSize +=  sizeof(sdrSize);
+    *respSize += sdrSize;
 
     return 0;
-
 }
 
 s8 Asdm_Get_Sensor_Repository(u8 *req, u8 *resp, u16 *respSize)
@@ -1223,11 +1220,6 @@ s8 Asdm_Process_Sensor_Request(u8 *req, u8 *resp, u16 *respSize)
     {
         VMC_ERR(" ASDM Data not Initialized yet or has Failed \n\r");
         return -1;
-    }
-
-    if(req[0] == ASDM_CMD_GET_SIZE)
-    {
-        return Asdm_Get_SDR_Size(req, resp, respSize);
     }
 
     if(!isRepoTypeSupported(req[1]))

--- a/vmr/src/vmc/vmc_asdm.h
+++ b/vmr/src/vmc/vmc_asdm.h
@@ -253,6 +253,7 @@ typedef struct __attribute__((packed)) {
 s8 Init_Asdm();
 void Asdm_Update_Sensors(void);
 s8 Asdm_Process_Sensor_Request(u8 *req, u8 *resp, u16 *respSize);
+s8 Asdm_Get_SDR_Size(u8 *req, u8 *resp, u16 *respSize);
 s8 PMBUS_SC_Sensor_Read(snsrRead_t *snsrData);
 s8 Temperature_Read_QSFP(snsrRead_t *snsrData);
 s8 Temperature_Read_VCCINT(snsrRead_t *snsrData);

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -330,12 +330,6 @@ static int validate_sensor_payload(struct xgq_vmr_sensor_payload *payload)
         return ret;
     }
 
-    /* Check if the Response Buffer is greater than Request buffer */
-    if (SENSOR_RESP_BUFFER_SIZE > payload->size) {
-        VMC_ERR("Resp size 0x%x exceeding Req size 0x%x",SENSOR_RESP_BUFFER_SIZE, payload->size);
-        return ret;
-    }
-
     return 0;
 }
 
@@ -351,6 +345,13 @@ int cl_vmc_sensor_request(cl_msg_t *msg)
     reqBuffer[0] = msg->sensor_payload.aid;
     reqBuffer[1] = msg->sensor_payload.sid;
     reqBuffer[2] = msg->sensor_payload.sensor_id;
+
+    if(reqBuffer[0] == ASDM_CMD_GET_SIZE)
+    {
+        Asdm_Get_SDR_Size(&reqBuffer[0], &respBuffer[0], &respSize);
+        msg->sensor_payload.size = respSize;
+        return ret;
+    }
 
     ret = validate_sensor_payload(&msg->sensor_payload);
     if (ret)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Use get_size sdr request to receive sensor data size

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is an enhancement to allocate the required sensor buffer size before processing sensor request.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Get sensor buffer size before and allocate buffer accordingly before processing sensor request.
#### Risks (if any) associated the changes in the commit
None.
#### What has been tested and how, request additional testing if necessary
1. Verify the sensor buffer information with changes in both XRT and VMR.
2. Verify the sensor buffer information with changes in VMR only to verify backward compatibility. In this case, the buffer size is allocated with 4096 default value. 
3. Verify the sensor buffer information with changes in XRT only to verify backward compatibility. In this case, the buffer size is allocated with 4096 default value. 
#### Documentation impact (if any)
None