### PR TITLE
CR-1198288 : Flashing VMR from XSDB resets the APU ready status

### DIFF
--- a/vmr/src/common/cl_main.c
+++ b/vmr/src/common/cl_main.c
@@ -299,7 +299,7 @@ static int cl_platform_init()
 	 * APU ready status aswell. Hence skip Initialization if APU is already UP.
 	 */
 	if (apu_channel_ready == 1) {
-		VMR_ERR("APU Channel is ready, skip initializing APU shared mem");
+		VMR_DBG("APU Channel is ready, skip initializing APU shared mem");
 	}
 	else
 	{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
If VMR is programmed via xsdb when APU is already UP, Initializing APU shared buffer resets APU ready status aswell. Hence skip Initialization if APU is already UP.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
If VMR is programmed via xsdb when APU is already UP, Initializing APU shared buffer resets APU ready status aswell. Hence skip Initialization if APU is already UP.
#### How problem was solved, alternative solutions (if any) and why they were rejected
skip Initialization if APU is already UP.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
1. Load XRT drivers and verify APU is UP.
2. Unload XRT drivers.
3. Flash VMR using xsdb.
4. Load XRT drivers.
5. Verify PS status
#### Documentation impact (if any)
N/A