### PR TITLE
CR-1189445 Read and update UUID from PLM as HW eliminates UUID from ROM

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 All VMR code is released under the terms of either Apache License, Version 2.0,
 or alternatively under the terms of the MIT.
 
-Copyright (C) 2016-2022 Xilinx, Inc.
+Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 The full text for both licenses is included for reference below.
 
@@ -184,7 +184,7 @@ The full text for both licenses is included for reference below.
 
 ---------------------------------------------------------------------------
 
-Copyright (C) 2016-2022 Xilinx, Inc.
+Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/avstack.pl
+++ b/build/avstack.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 # avstack.pl: AVR stack checker
 # Copyright (C) 2013 Daniel Beer <dlbeer@gmail.com>

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 TOOL_VERSION="2023.1"
 DEFAULT_VITIS="/proj/xbuilds/${TOOL_VERSION}_daily_latest/installs/lin64/Vitis/HEAD/settings64.sh"

--- a/build/config_app.tcl
+++ b/build/config_app.tcl
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 setws .
 puts "=== config app"

--- a/build/config_vmr_app_RMI.tcl
+++ b/build/config_vmr_app_RMI.tcl
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 set i 0; foreach n $argv {set [incr i] $n}
 puts "add library and path: $1 $2 "

--- a/build/create_app.tcl
+++ b/build/create_app.tcl
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 setws .
 puts "create app"

--- a/build/create_bsp.tcl
+++ b/build/create_bsp.tcl
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 set i 0; foreach n $argv {set [incr i] $n}
 puts "create with xsa: $1 jtag: $2"

--- a/build/lscript.ld
+++ b/build/lscript.ld
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  */
 
 /*******************************************************************/
@@ -9,7 +9,7 @@
 /*                                                                 */
 /* Version: 2018.3                                                 */
 /*                                                                 */
-/* Copyright (c) 2010-2019 Xilinx, Inc.  All rights reserved.      */
+/* Copyright (C) 2024 AMD, Inc.    All rights reserved.            */
 /*                                                                 */
 /* Description : Cortex-R5 Linker Script                           */
 /*                                                                 */

--- a/build/lscript_rave.ld
+++ b/build/lscript_rave.ld
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  */
 
 /*******************************************************************/
@@ -9,7 +9,7 @@
 /*                                                                 */
 /* Version: 2018.3                                                 */
 /*                                                                 */
-/* Copyright (c) 2010-2019 Xilinx, Inc.  All rights reserved.      */
+/* Copyright (C) 2024 AMD, Inc.    All rights reserved.            */
 /*                                                                 */
 /* Description : Cortex-R5 Linker Script                           */
 /*                                                                 */

--- a/build/make_app.tcl
+++ b/build/make_app.tcl
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 setws .
 puts "build app"

--- a/build/regen_pdi.sh
+++ b/build/regen_pdi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 ############################################################
 # Help                                                     #

--- a/build/regen_vmrpdi.sh
+++ b/build/regen_vmrpdi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 ############################################################
 # Help                                                     #

--- a/build/stack_usage.sh
+++ b/build/stack_usage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 TOOL_VERSION="2022.1"
 DEFAULT_VITIS="/proj/xbuilds/${TOOL_VERSION}_daily_latest/installs/lin64/Vitis/HEAD/settings64.sh"

--- a/build/update_VMR_vitis_project.sh
+++ b/build/update_VMR_vitis_project.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 cd vmr/
 rm -r src/

--- a/build/upgrade_vmr.sh
+++ b/build/upgrade_vmr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2024 AMD, Inc.    All rights reserved.
 
 ############################################################
 # Help                                                     #

--- a/docker/docker-compose-gha.yml
+++ b/docker/docker-compose-gha.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, Xilinx Inc
+#  Copyright (C) 2024 AMD, Inc.    All rights reserved.
 #
 #  Apache License Verbiage
 #

--- a/docker/docker-compose-jenkins.yml
+++ b/docker/docker-compose-jenkins.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, Xilinx Inc
+#  Copyright (C) 2024 AMD, Inc.    All rights reserved.
 #
 #  Apache License Verbiage
 #

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, Xilinx Inc
+#  Copyright (C) 2024 AMD, Inc.    All rights reserved.
 #
 #  Apache License Verbiage
 #

--- a/docker/setUserEnv.sh
+++ b/docker/setUserEnv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-#  Copyright (C) 2021, Xilinx Inc
+#  Copyright (C) 2024 AMD, Inc.    All rights reserved.
 #
 #  Apache License Verbiage
 #

--- a/vmr/src/common/cl_i2c.c
+++ b/vmr/src/common/cl_i2c.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/common/cl_log.c
+++ b/vmr/src/common/cl_log.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_main.c
+++ b/vmr/src/common/cl_main.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_mem.c
+++ b/vmr/src/common/cl_mem.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/common/cl_ospi_polled.c
+++ b/vmr/src/common/cl_ospi_polled.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2018 - 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/common/cl_rmi.c
+++ b/vmr/src/common/cl_rmi.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * * Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+ * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * * SPDX-License-Identifier: MIT
  * *******************************************************************************/
 

--- a/vmr/src/common/cl_uart_rtos.c
+++ b/vmr/src/common/cl_uart_rtos.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/common/cl_vmc_sc_comms.c
+++ b/vmr/src/common/cl_vmc_sc_comms.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_vmc_sensor.c
+++ b/vmr/src/common/cl_vmc_sensor.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_xgq_client.c
+++ b/vmr/src/common/cl_xgq_client.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_xgq_client_plat.h
+++ b/vmr/src/common/cl_xgq_client_plat.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/common/cl_xgq_opcode.c
+++ b/vmr/src/common/cl_xgq_opcode.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_xgq_program.c
+++ b/vmr/src/common/cl_xgq_program.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_xgq_receive.c
+++ b/vmr/src/common/cl_xgq_receive.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 /* FreeRTOS includes */

--- a/vmr/src/common/cl_xgq_receive_plat.h
+++ b/vmr/src/common/cl_xgq_receive_plat.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/common/xgq_cmd_common.h
+++ b/vmr/src/common/xgq_cmd_common.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/common/xgq_cmd_vmr.h
+++ b/vmr/src/common/xgq_cmd_vmr.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/common/xgq_impl.h
+++ b/vmr/src/common/xgq_impl.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * Copyright (C) 2023, Advanced Micro Devices, Inc.  All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/

--- a/vmr/src/common/xospipsv_flash_config.h
+++ b/vmr/src/common/xospipsv_flash_config.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_config.h
+++ b/vmr/src/include/cl_config.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_flash.h
+++ b/vmr/src/include/cl_flash.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_i2c.h
+++ b/vmr/src/include/cl_i2c.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_io.h
+++ b/vmr/src/include/cl_io.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_log.h
+++ b/vmr/src/include/cl_log.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_main.h
+++ b/vmr/src/include/cl_main.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_mem.h
+++ b/vmr/src/include/cl_mem.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_msg.h
+++ b/vmr/src/include/cl_msg.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_rmgmt.h
+++ b/vmr/src/include/cl_rmgmt.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_rmi.h
+++ b/vmr/src/include/cl_rmi.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * * Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+ * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * * SPDX-License-Identifier: MIT
  * ****************************************************************************/
 

--- a/vmr/src/include/cl_uart_rtos.h
+++ b/vmr/src/include/cl_uart_rtos.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_version.h
+++ b/vmr/src/include/cl_version.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/cl_vmc.h
+++ b/vmr/src/include/cl_vmc.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/include/vmr_common.h
+++ b/vmr/src/include/vmr_common.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/gic_setup.c
+++ b/vmr/src/rmgmt/gic_setup.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #include "gic_setup.h"

--- a/vmr/src/rmgmt/gic_setup.h
+++ b/vmr/src/rmgmt/gic_setup.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #ifndef LIBESWPM_GIC_SETUP_H_

--- a/vmr/src/rmgmt/ipi.c
+++ b/vmr/src/rmgmt/ipi.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #include "pm_api_sys.h"

--- a/vmr/src/rmgmt/ipi.h
+++ b/vmr/src/rmgmt/ipi.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #ifndef LIBESWPM_PM_IPI_H_

--- a/vmr/src/rmgmt/pm_init.c
+++ b/vmr/src/rmgmt/pm_init.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #include "pm_api_sys.h"

--- a/vmr/src/rmgmt/pm_init.h
+++ b/vmr/src/rmgmt/pm_init.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #ifndef _PM_INIT_H_

--- a/vmr/src/rmgmt/rmgmt_clock.c
+++ b/vmr/src/rmgmt/rmgmt_clock.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_clock.h
+++ b/vmr/src/rmgmt/rmgmt_clock.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_common.h
+++ b/vmr/src/rmgmt/rmgmt_common.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_fpt.c
+++ b/vmr/src/rmgmt/rmgmt_fpt.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_fpt.h
+++ b/vmr/src/rmgmt/rmgmt_fpt.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_ipi.c
+++ b/vmr/src/rmgmt/rmgmt_ipi.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_ipi.h
+++ b/vmr/src/rmgmt/rmgmt_ipi.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_main.c
+++ b/vmr/src/rmgmt/rmgmt_main.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_pm.c
+++ b/vmr/src/rmgmt/rmgmt_pm.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_pm.h
+++ b/vmr/src/rmgmt/rmgmt_pm.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_xclbin.c
+++ b/vmr/src/rmgmt/rmgmt_xclbin.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_xclbin.h
+++ b/vmr/src/rmgmt/rmgmt_xclbin.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_xfer.c
+++ b/vmr/src/rmgmt/rmgmt_xfer.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/rmgmt_xfer.h
+++ b/vmr/src/rmgmt/rmgmt_xfer.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/rmgmt/xclbin.h
+++ b/vmr/src/rmgmt/xclbin.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/clock_throttling.c
+++ b/vmr/src/vmc/clock_throttling.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 - 2022 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 #include "clock_throttling.h"

--- a/vmr/src/vmc/clock_throttling.h
+++ b/vmr/src/vmc/clock_throttling.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 - 2022 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 #include "xil_types.h"

--- a/vmr/src/vmc/platforms/v70.c
+++ b/vmr/src/vmc/platforms/v70.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/platforms/v70.h
+++ b/vmr/src/vmc/platforms/v70.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/platforms/v80.c
+++ b/vmr/src/vmc/platforms/v80.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright ( C ) 2023 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/platforms/v80.h
+++ b/vmr/src/vmc/platforms/v80.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright ( C ) 2023 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/platforms/vck5000.c
+++ b/vmr/src/vmc/platforms/vck5000.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #include "cl_vmc.h"

--- a/vmr/src/vmc/platforms/vck5000.h
+++ b/vmr/src/vmc/platforms/vck5000.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/cat34ts02.h
+++ b/vmr/src/vmc/sensors/inc/cat34ts02.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2023 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/ina3221.h
+++ b/vmr/src/vmc/sensors/inc/ina3221.h
@@ -1,6 +1,6 @@
 
 /******************************************************************************
- * * Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+ * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * * SPDX-License-Identifier: MIT
  * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/isl68221.h
+++ b/vmr/src/vmc/sensors/inc/isl68221.h
@@ -1,6 +1,6 @@
 
 /******************************************************************************
- * * Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+ * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * * SPDX-License-Identifier: MIT
  * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/lm75.h
+++ b/vmr/src/vmc/sensors/inc/lm75.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- *  * * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ *  * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  *   * * SPDX-License-Identifier: MIT
  *    * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/m24c128.h
+++ b/vmr/src/vmc/sensors/inc/m24c128.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/max6639.h
+++ b/vmr/src/vmc/sensors/inc/max6639.h
@@ -1,7 +1,7 @@
 
 
 /******************************************************************************
- * * Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+ * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * * SPDX-License-Identifier: MIT
  * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/qsfp.h
+++ b/vmr/src/vmc/sensors/inc/qsfp.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/inc/se98a.h
+++ b/vmr/src/vmc/sensors/inc/se98a.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/cat34ts02.c
+++ b/vmr/src/vmc/sensors/src/cat34ts02.c
@@ -1,5 +1,5 @@
 /******************************************************************************usTempHexVal
- * Copyright (C) 2023 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/ina3221.c
+++ b/vmr/src/vmc/sensors/src/ina3221.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- *  * * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ *  * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  *   * * SPDX-License-Identifier: MIT
  *    * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/isl68221.c
+++ b/vmr/src/vmc/sensors/src/isl68221.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- *  * * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ *  * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  *   * * SPDX-License-Identifier: MIT
  *    * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/lm75.c
+++ b/vmr/src/vmc/sensors/src/lm75.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * * SPDX-License-Identifier: MIT
  * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/m24c128.c
+++ b/vmr/src/vmc/sensors/src/m24c128.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/max6639.c
+++ b/vmr/src/vmc/sensors/src/max6639.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * * Copyright ( C ) 2021 Xilinx, Inc.  All rights reserved.
+ * * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * * SPDX-License-Identifier: MIT
  * *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/qsfp.c
+++ b/vmr/src/vmc/sensors/src/qsfp.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2023 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/sensors/src/se98a.c
+++ b/vmr/src/vmc/sensors/src/se98a.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_api.c
+++ b/vmr/src/vmc/vmc_api.c
@@ -1,6 +1,6 @@
 
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_api.h
+++ b/vmr/src/vmc/vmc_api.h
@@ -1,6 +1,6 @@
 
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #ifndef INC_VMC_API_H_

--- a/vmr/src/vmc/vmc_asdm.c
+++ b/vmr/src/vmc/vmc_asdm.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_asdm.h
+++ b/vmr/src/vmc/vmc_asdm.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2023 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 #ifndef INC_VMC_ASDM_H_

--- a/vmr/src/vmc/vmc_demo.c
+++ b/vmr/src/vmc/vmc_demo.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_main.c
+++ b/vmr/src/vmc/vmc_main.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_main.h
+++ b/vmr/src/vmc/vmc_main.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_sc_comms.c
+++ b/vmr/src/vmc/vmc_sc_comms.c
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_sc_comms.h
+++ b/vmr/src/vmc/vmc_sc_comms.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2024 AMD, Inc.    All rights reserved.
 * SPDX-License-Identifier: MIT
 *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_sensors.c
+++ b/vmr/src/vmc/vmc_sensors.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020-2022 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_sensors.h
+++ b/vmr/src/vmc/vmc_sensors.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_update_sc.c
+++ b/vmr/src/vmc/vmc_update_sc.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 

--- a/vmr/src/vmc/vmc_update_sc.h
+++ b/vmr/src/vmc/vmc_update_sc.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2020 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2024 AMD, Inc.    All rights reserved.
  * SPDX-License-Identifier: MIT
  *******************************************************************************/
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
HW ROM eliminates UUID information from HW.
VMR fetches the UUID information from PLM and updates the same in VSEC region.
Host/XRT fetches the UUID information that VMR writes to. ( No changes in XRT required).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected
NA
#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
1. Tested on Debug XSA that eliminated UUID in HW ROM
2. Tested VMR on V70 platform to ensure the regular functionality has not effected.
 
#### Documentation impact (if any)
UUID Documentation flow needs an update.