### PR TITLE
 CR-1189445 Pushing HW UUID ROM ID changes to SDT MAIN Branch

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -162,6 +162,7 @@ python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/create_bsp.py -p psv_cortex
 python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/config_bsp.py -d ./ -al xilmailbox
 python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/config_bsp.py -d ./ -al xilpm
 python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/config_bsp.py -d ./ -al xilfpga
+python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/config_bsp.py -d ./ -al xilloader
 python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/config_bsp.py -d ./ -st freertos freertos_generate_runtime_stats:0x1
 python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/config_bsp.py -d ./ -st freertos freertos_total_heap_size:369098752
 python ${XILINX_VITIS}/data/embeddedsw/scripts/pyesw/config_bsp.py -d ./ -st freertos freertos_stream_buffer:true

--- a/vmr/src/include/vmr_common.h
+++ b/vmr/src/include/vmr_common.h
@@ -129,12 +129,19 @@
 #define RPU_SHARED_MEMORY_ADDR(offset) (VMR_EP_RPU_SHARED_MEMORY_START + (u32)offset)
 #define APU_SHARED_MEMORY_ADDR(offset) (VMR_EP_APU_SHARED_MEMORY_START + (u32)offset)
 
+/* S0 AXI UUID Register mapped to S1 AXI 0x20102002000 via qdma */
+#if defined(CONFIG_RAVE)
+#define XPAR_BLP_BLP_LOGIC_UUID_S0_AXI_ADDR 0x80045000
+#endif
+
 #define SHUTDOWN_LATCHED_STATUS	0x01
 #define MAX_GAPPING_DEMAND_RATE 128
 #define CONVERT_TO_PERCENTAGE  100
 #define MAX_CLOCK_SPEED_PERCENTAGE 100
 
+#ifndef BIT
 #define BIT(n) 			(1UL << (n))
+#endif
 #define MIN(x, y) 		(((x) < (y)) ? (x) : (y))
 
 struct vmr_endpoints {
@@ -168,7 +175,7 @@ static inline int rmgmt_enable_pl_reset() { return -ENODEV; }
  * This is a workaround for RAVE Build only.
  */
 #undef VCCINT
-#define VCCINT 1 
+#define VCCINT 1
 #endif // endif of CONFIG_RAVE
 
 #endif //endif of VMR_COMMON_H

--- a/vmr/src/rmgmt/rmgmt_pm.h
+++ b/vmr/src/rmgmt/rmgmt_pm.h
@@ -11,5 +11,6 @@ struct cl_msg;
 int rmgmt_pm_init(void);
 int rmgmt_pm_reset_rpu(struct cl_msg *msg);
 int rmgmt_eemi_pm_reset(struct cl_msg *msg);
+int rmgmt_plm_get_uid(int* uuid);
 
 #endif


### PR DESCRIPTION
Problem solved by the commit
HW ROM eliminates UUID information from HW.
VMR fetches the UUID information from PLM and updates the same in VSEC region.
Host/XRT fetches the UUID information that VMR writes to. ( No changes in XRT required).

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

How problem was solved, alternative solutions (if any) and why they were rejected
NA

Risks (if any) associated the changes in the commit
NA

What has been tested and how, request additional testing if necessary
Tested on Debug XSA that eliminated UUID in HW ROM
Tested VMR on V70 platform to ensure the regular functionality has not effected.
Documentation impact (if any)
UUID Documentation flow needs an update.